### PR TITLE
Ensure windows line ending for t4 files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -187,3 +187,7 @@ indent_size = 2
 end_of_line = lf
 [*.{cmd,bat}]
 end_of_line = crlf
+
+# T4 files
+[*.tt]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+*.tt text eol=crlf
+*.sh text eol=lf
+*.cmd text eol=crlf
+*.bat text eol=crlf


### PR DESCRIPTION
t4 files need to have windows line ending. To ensure this editorconfig is extended and gitattributes are introduced.