### PR TITLE
fix: make profile name a required argument for select/delete

### DIFF
--- a/src/modules/dgt.power.profile/Commands/NamedProfileSettings.cs
+++ b/src/modules/dgt.power.profile/Commands/NamedProfileSettings.cs
@@ -10,7 +10,7 @@ namespace dgt.power.profile.Commands;
 
 public class NamedProfileSettings : ProfileSettings
 {
-    [CommandArgument(0, "[Name]")]
+    [CommandArgument(0, "<Name>")]
     [Description("Name")]
     public string Name { get; init; }
 }


### PR DESCRIPTION
If not

`dgtp profile select`

leads to an NullReferenceException