### PR TITLE
Command to quickly enable/disable plugin steps within a solution

### DIFF
--- a/src/dgt.power/Program.cs
+++ b/src/dgt.power/Program.cs
@@ -147,7 +147,9 @@ app.Configure(config =>
             maintenance.AddCommand<FilterPowerFxPluginSteps>("filterfxplugins")
                 .WithDescription("Add Messagefiltering for PowerFx Plugins")
                 .WithExample("maintenance","filterfxplugins","--config", "./config.json");
-            maintenance.AddCommand<EnsureSdkStepStatus>("ensuresdksteps");
+            maintenance.AddCommand<EnsureSdkStepStatus>("ensuresdksteps")
+                .WithDescription("Ensure sdk steps within a solution are enabled (or disabled)")
+                .WithExample("maintenance", "ensuresdksteps", "--solution", "assemblies");
 
         });
 

--- a/src/dgt.power/Program.cs
+++ b/src/dgt.power/Program.cs
@@ -147,6 +147,7 @@ app.Configure(config =>
             maintenance.AddCommand<FilterPowerFxPluginSteps>("filterfxplugins")
                 .WithDescription("Add Messagefiltering for PowerFx Plugins")
                 .WithExample("maintenance","filterfxplugins","--config", "./config.json");
+            maintenance.AddCommand<EnsureSdkStepStatus>("ensuresdksteps");
 
         });
 

--- a/src/modules/dgt.power.maintenance/Logic/EnsureSdkStepStatus.cs
+++ b/src/modules/dgt.power.maintenance/Logic/EnsureSdkStepStatus.cs
@@ -22,6 +22,11 @@ namespace dgt.power.maintenance.Logic
             [Description("unique name of the solution to work on")]
             [DefaultValue("assemblies")]
             public string? Solution { get; set; }
+
+            [CommandOption("-d|--disabled")]
+            [Description("true if steps should be disabled, false otherwise")]
+            [DefaultValue(false)]
+            public bool Disabled { get; set; }
         }
 
         protected override bool Invoke(Settings args) => InvokeAsync(args).GetAwaiter().GetResult();
@@ -47,10 +52,12 @@ namespace dgt.power.maintenance.Logic
                         var stepName = sdkStep.Name.EscapeMarkup();
                         var stepId = sdkStep.Id.ToString();
 
-                        var status = sdkStep.StateCode?.Value switch
+                        var status = (sdkStep.StateCode?.Value, args.Disabled) switch
                         {
-                            SdkMessageProcessingStep.Options.StateCode.Enabled => "[green]Enabled[/]",
-                            SdkMessageProcessingStep.Options.StateCode.Disabled => "[grey]Disabled[/]",
+                            (SdkMessageProcessingStep.Options.StateCode.Enabled, false)=> "[green]Enabled[/]",
+                            (SdkMessageProcessingStep.Options.StateCode.Enabled, true)=> "[red]Enabled[/]",
+                            (SdkMessageProcessingStep.Options.StateCode.Disabled, false) => "[red]Disabled[/]",
+                            (SdkMessageProcessingStep.Options.StateCode.Disabled, true) => "[grey]Disabled[/]",
                             _ => "[red]Unknown[/]",
                         };
 

--- a/src/modules/dgt.power.maintenance/Logic/EnsureSdkStepStatus.cs
+++ b/src/modules/dgt.power.maintenance/Logic/EnsureSdkStepStatus.cs
@@ -87,12 +87,9 @@ namespace dgt.power.maintenance.Logic
                             };
                             await ((IOrganizationServiceAsync2)Connection).ExecuteAsync(updateRequest);
 
-                            status = desiredStateValue switch
-                            {
-                                SdkMessageProcessingStep.Options.StateCode.Disabled => "[grey]Disabled[/]",
-                                SdkMessageProcessingStep.Options.StateCode.Enabled => "[green]Enabled[/]",
-                                _ => "[red]Unknown[/]",
-                            };
+                            status = desiredStateValue == SdkMessageProcessingStep.Options.StateCode.Disabled
+                                ? "[grey]Disabled[/]"
+                                : "[green]Enabled[/]";
 
                             table.UpdateCell(rowIndex, 2, status);
                             ctx.Refresh();

--- a/src/modules/dgt.power.maintenance/Logic/EnsureSdkStepStatus.cs
+++ b/src/modules/dgt.power.maintenance/Logic/EnsureSdkStepStatus.cs
@@ -27,6 +27,11 @@ namespace dgt.power.maintenance.Logic
             [Description("true if steps should be disabled, false otherwise")]
             [DefaultValue(false)]
             public bool Disabled { get; set; }
+
+            [CommandOption("--dry-run")]
+            [Description("do not perform any updates")]
+            [DefaultValue(false)]
+            public bool DryRun { get; set; }
         }
 
         protected override bool Invoke(Settings args) => InvokeAsync(args).GetAwaiter().GetResult();
@@ -76,7 +81,7 @@ namespace dgt.power.maintenance.Logic
                             ? SdkMessageProcessingStep.Options.StateCode.Disabled
                             : SdkMessageProcessingStep.Options.StateCode.Enabled;
 
-                        if (sdkStep.StateCode?.Value != desiredStateValue)
+                        if (!args.DryRun && sdkStep.StateCode?.Value != desiredStateValue)
                         {
                             var updateRequest = new UpdateRequest
                             {

--- a/src/modules/dgt.power.maintenance/Logic/EnsureSdkStepStatus.cs
+++ b/src/modules/dgt.power.maintenance/Logic/EnsureSdkStepStatus.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) DIGITALL Nature. All rights reserved
+// DIGITALL Nature licenses this file to you under the Microsoft Public License.
+
+using System.ComponentModel;
+using dgt.power.common;
+using dgt.power.dataverse;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Query;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace dgt.power.maintenance.Logic
+{
+    public class EnsureSdkStepStatus(ITracer tracer, IOrganizationService connection, IConfigResolver configResolver)
+        : PowerLogic<EnsureSdkStepStatus.Settings>(tracer, connection, configResolver)
+    {
+        public class Settings : BaseProgramSettings
+        {
+            [CommandOption("-s|--solution")]
+            [Description("unique name of the solution to work on")]
+            [DefaultValue("assemblies")]
+            public string? Solution { get; set; }
+        }
+
+        protected override bool Invoke(Settings args) => InvokeAsync(args).GetAwaiter().GetResult();
+
+        private async Task<bool> InvokeAsync(Settings args)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(args.Solution);
+
+            await AnsiConsole.Status()
+                .StartAsync("Loading sdk steps", async ctx =>
+                {
+                    var sdkSteps = await RetrieveSdkSteps(args.Solution);
+
+                    var table = new Table()
+                        .AddColumn("Plugin Type")
+                        .AddColumn("Step Name")
+                        .AddColumn("Status")
+                        .AddColumn("Step Id");
+
+                    foreach (var sdkStep in sdkSteps.OrderBy(s => s.PluginTypeId?.Id).ThenBy(s => s.Name))
+                    {
+                        var pluginType = sdkStep.PluginTypeId?.Id.ToString() ?? string.Empty;
+                        var stepName = sdkStep.Name.EscapeMarkup();
+                        var stepId = sdkStep.Id.ToString();
+
+                        var status = sdkStep.StateCode?.Value switch
+                        {
+                            SdkMessageProcessingStep.Options.StateCode.Enabled => "[green]Enabled[/]",
+                            SdkMessageProcessingStep.Options.StateCode.Disabled => "[grey]Disabled[/]",
+                            _ => "[red]Unknown[/]",
+                        };
+
+                        table.AddRow(pluginType, stepName, status, stepId);
+                    }
+
+                    AnsiConsole.Write(table);
+                });
+
+            return true;
+        }
+
+        private async Task<SdkMessageProcessingStep[]> RetrieveSdkSteps(string solutionName)
+        {
+            var query = new QueryExpression(SdkMessageProcessingStep.EntityLogicalName)
+            {
+                ColumnSet = new ColumnSet(
+                    SdkMessageProcessingStep.LogicalNames.StateCode,
+                    SdkMessageProcessingStep.LogicalNames.Name,
+                    SdkMessageProcessingStep.LogicalNames.PluginTypeId
+                ),
+            };
+
+            var componentLink = query.AddLink(SolutionComponent.EntityLogicalName, SdkMessageProcessingStep.LogicalNames.SdkMessageProcessingStepId, SolutionComponent.LogicalNames.ObjectId);
+            var solutionLink = componentLink.AddLink(Solution.EntityLogicalName, SolutionComponent.LogicalNames.SolutionId, Solution.LogicalNames.SolutionId);
+            solutionLink.EntityAlias = "solution";
+
+            query.Criteria.AddCondition("solution", Solution.LogicalNames.UniqueName, ConditionOperator.Like, solutionName);
+
+            var retrieveMultipleRequest = new RetrieveMultipleRequest
+            {
+                Query = query,
+            };
+            var orgResponse = await ((IOrganizationServiceAsync2)Connection).ExecuteAsync(retrieveMultipleRequest);
+
+            var sdkSteps = (orgResponse as RetrieveMultipleResponse)?.EntityCollection.Entities.Cast<SdkMessageProcessingStep>().ToArray() ?? [];
+
+            return sdkSteps;
+        }
+    }
+}


### PR DESCRIPTION
* works with a given solution(-pattern)
* by default enables the steps - can be changed by adding `--disabled` flag
* prints a table with plugin type id, step name and state
* `--dry-run` function to run without performing any updates