### PR TITLE
fix: use home account identifier for msal token

### DIFF
--- a/src/dgt.power.common/Logic/TokenConnector.cs
+++ b/src/dgt.power.common/Logic/TokenConnector.cs
@@ -57,7 +57,7 @@ internal class TokenConnector : IConnector
                 .WithClaims(ex.Claims)
                 .ExecuteAsync();
 
-            _identity.Username = interactive.Account.Username;
+            _identity.Username = interactive.Account.HomeAccountId.Identifier;
             _account = interactive.Account;
             _profileManager.Save();
 


### PR DESCRIPTION
fixes #93 