### PR TITLE
Custom entity form generation

### DIFF
--- a/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerLight.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerLight.cs
@@ -90,14 +90,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
                 SchemaName = metadata.SchemaName,
                 LogicalName = metadata.LogicalName,
                 LanguageCode = languageCode,
-                Attributes = metadata.Attributes
-                    .Where(a =>
-                        (a.IsValidForGrid == true || a.IsValidForForm == true || a.IsValidODataAttribute ||
-                         a.IsPrimaryId == true) && (a.IsValidForCreate == true || a.IsValidForUpdate == true ||
-                                                    a.IsValidForRead == true))
-                    .Where(a => !a.LogicalName.Contains("entityimage"))
-                    .Where(a => a.AttributeType != AttributeTypeCode.ManagedProperty)
-                    .OrderBy(a => a.LogicalName).ToList()
+                Attributes = FilterEntityMetadataAttributes(metadata),
             };
             var context = new TemplateContext(viewModel, _templateOptions);
             var content = liquidTemplate.Render(context);
@@ -117,6 +110,11 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         foreach (var entity in config.Entities)
         {
             var metadata = _metadataService.RetrieveEntityMetadata(entity, EntityFilters.Attributes | EntityFilters.Entity);
+            // do not create forms for bpf entities
+            if (metadata.IsBPFEntity == true)
+            {
+                break;
+            }
 
             var forms = config.OnlyFormsFromSolutions
                 ? _metadataService.RetrieveFormsDetailsFromSolutions(metadata.LogicalName, config.Solutions)
@@ -124,47 +122,14 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
 
             foreach (var formDetail in forms)
             {
-                var form =  $"{metadata.LogicalName}.{Formatter.Sanitize(formDetail.Key.ToLowerInvariant(), true).Replace(' ', '_')}.{FileNames.Typescript.Form}";
-                if (config.Forms.Length != 0)
+                var formName =  $"{metadata.LogicalName}.{Formatter.Sanitize(formDetail.Key.ToLowerInvariant(), true).Replace(' ', '_')}.{FileNames.Typescript.Form}";
+                if (ShouldSkipFormForConfig(config.Forms, formName))
                 {
-                    config.Forms.Where(e => e.EndsWith(".ts", StringComparison.InvariantCulture))
-                        .ToList()
-                        .ForEach(e => AnsiConsole.MarkupLine(Warnings.TsExtensionDeprecation));
-                    config.Forms = config.Forms.Select(e => e.EndsWith(".ts", StringComparison.InvariantCulture)
-                                ? e.Remove(e.LastIndexOf(".ts", StringComparison.Ordinal))
-                                : e)
-                        .ToArray();
-                }
-
-                if (config.Forms.Length != 0 && !config.Forms.Contains(form))
-                {
-                    AnsiConsole.MarkupLine($"Skip: {form}");
+                    AnsiConsole.MarkupLine($"Skip: {formName}");
                     continue;
                 }
 
-                var formname = formDetail.Key
-                    .Replace(".main", "Main").Replace(".quickview", "QuickView")
-                    .Replace(".quickcreate", "QuickCreate");
-
-                var viewModel = new FormViewModel
-                {
-                    Name = formname,
-                    FormDetail = formDetail.Value,
-                    SchemaName = metadata.SchemaName,
-                    Attributes = metadata.Attributes
-                        .Where(a =>
-                            (a.IsValidForGrid == true || a.IsValidForForm == true || a.IsValidODataAttribute ||
-                             a.IsPrimaryId == true) && (a.IsValidForCreate == true || a.IsValidForUpdate == true ||
-                                                        a.IsValidForRead == true))
-                        .Where(a => !a.LogicalName.Contains("entityimage"))
-                        .Where(a => a.AttributeType != AttributeTypeCode.ManagedProperty)
-                        .OrderBy(a => a.LogicalName).ToList()
-                };
-
-                var context = new TemplateContext(viewModel, _templateOptions);
-                var content = liquidTemplate.Render(context);
-
-                CreateFile(content, form, args);
+                CreateFormFile(formDetail, metadata, liquidTemplate, args, formName);
 
                 // var template = new EntityLightFormTemplate(config.TypingPath, form, formname, formDetail.Value,
                 //     metadata, config, _metadataService.RetrieveOrganizationLanguage());
@@ -239,6 +204,75 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         var content = liquidTemplate.Render(context);
 
         CreateFile(content, FileNames.Typescript.OptionSetValues, args);
+    }
+
+    /// <summary>
+    /// Wrapper function that maps the model and creates the form file
+    /// </summary>
+    /// <param name="formDetail"></param>
+    /// <param name="metadata"></param>
+    /// <param name="liquidTemplate"></param>
+    /// <param name="args"></param>
+    /// <param name="form"></param>
+    private void CreateFormFile(KeyValuePair<string, FormDetail> formDetail, EntityMetadata metadata, IFluidTemplate liquidTemplate, CodeGenerationVerb args, string form)
+    {
+        var formname = formDetail.Key
+                    .Replace(".main", "Main").Replace(".quickview", "QuickView")
+                    .Replace(".quickcreate", "QuickCreate");
+
+        var viewModel = new FormViewModel
+        {
+            Name = formname,
+            FormDetail = formDetail.Value,
+            SchemaName = metadata.SchemaName,
+            Attributes = FilterEntityMetadataAttributes(metadata),
+        };
+
+        var context = new TemplateContext(viewModel, _templateOptions);
+        var content = liquidTemplate.Render(context);
+
+        CreateFile(content, form, args);
+    }
+
+
+    /// <summary>
+    /// Checks given the configu and the form name if the form should be skipped for some reason or not
+    /// </summary>
+    /// <param name="configForms"></param>
+    /// <param name="form"></param>
+    /// <returns></returns>
+    private static bool ShouldSkipFormForConfig(string[] configForms, string form)
+    {
+        if (configForms.Length == 0)
+        {
+            return false;
+        }
+        configForms.Where(e => e.EndsWith(".ts", StringComparison.InvariantCulture))
+            .ToList()
+            .ForEach(e => AnsiConsole.MarkupLine(Warnings.TsExtensionDeprecation));
+        configForms = configForms.Select(e => e.EndsWith(".ts", StringComparison.InvariantCulture)
+                    ? e.Remove(e.LastIndexOf(".ts", StringComparison.Ordinal))
+                    : e)
+            .ToArray();
+
+        return !configForms.Contains(form);
+    }
+
+    /// <summary>
+    /// Filter metadata attributes before mapping them to entity or form models
+    /// </summary>
+    /// <param name="metadata"></param>
+    /// <returns></returns>
+    private static List<AttributeMetadata> FilterEntityMetadataAttributes(EntityMetadata metadata)
+    {
+        return metadata.Attributes
+            .Where(a =>
+                (a.IsValidForGrid == true || a.IsValidForForm == true || a.IsValidODataAttribute ||
+                    a.IsPrimaryId == true) && (a.IsValidForCreate == true || a.IsValidForUpdate == true ||
+                                            a.IsValidForRead == true))
+            .Where(a => !a.LogicalName.Contains("entityimage"))
+            .Where(a => a.AttributeType != AttributeTypeCode.ManagedProperty)
+            .OrderBy(a => a.LogicalName).ToList();
     }
 
     #endregion

--- a/src/modules/dgt.power.codegeneration/Services/MetadataService.cs
+++ b/src/modules/dgt.power.codegeneration/Services/MetadataService.cs
@@ -593,27 +593,96 @@ public class MetadataService : IMetadataService
     public Dictionary<string, FormDetail> RetrieveFormsDetailsFromSolutions(string entityLogicalName,
         string[] configSolutions)
     {
-        // 1.) Retrieve "allowed§ Forms
-        var querySolutionForms = new QueryExpression(SolutionComponent.EntityLogicalName);
-        querySolutionForms.ColumnSet.AddColumns(SolutionComponent.LogicalNames.ObjectId);
-        querySolutionForms.Criteria.AddCondition(SolutionComponent.LogicalNames.ComponentType, ConditionOperator.Equal,
-            SolutionComponent.Options.ComponentType.SystemForm);
-        var solutionLink = querySolutionForms.AddLink(Solution.EntityLogicalName,
-            SolutionComponent.LogicalNames.SolutionId, Solution.LogicalNames.SolutionId);
-        solutionLink.LinkCriteria.FilterOperator = LogicalOperator.Or;
-        foreach (var configSolution in configSolutions)
+        var querySystemForm = new QueryExpression(SystemForm.EntityLogicalName);
+        querySystemForm.ColumnSet.AddColumns(
+            SystemForm.LogicalNames.ObjectTypeCode,
+            SystemForm.LogicalNames.FormXml,
+            SystemForm.LogicalNames.Name,
+            SystemForm.LogicalNames.FormId,
+            SystemForm.LogicalNames.Type);
+        querySystemForm.Criteria.AddCondition(SystemForm.LogicalNames.ObjectTypeCode, ConditionOperator.Equal, entityLogicalName);
+        querySystemForm.Criteria.AddCondition(
+            SystemForm.LogicalNames.Type,
+            ConditionOperator.In,
+            SystemForm.Options.Type.Main,
+            SystemForm.Options.Type.QuickViewForm,
+            SystemForm.Options.Type.QuickCreate);
+        querySystemForm.Criteria.AddCondition(
+            SystemForm.LogicalNames.FormActivationState,
+            ConditionOperator.Equal,
+            SystemForm.Options.FormActivationState.Active);
+
+        // System form linked through the solution component
+        var query_Or = new FilterExpression(LogicalOperator.Or);
+        querySystemForm.Criteria.AddFilter(query_Or);
+        var query_Or_Or1 = new FilterExpression(LogicalOperator.Or);
+        query_Or.AddFilter(query_Or_Or1);
+        var query_Or_Or1_solutioncomponent = new LinkEntity(
+            SystemForm.EntityLogicalName,
+            SolutionComponent.EntityLogicalName,
+            SystemForm.LogicalNames.FormId,
+            SolutionComponent.LogicalNames.ObjectId,
+            JoinOperator.Any);
+        query_Or_Or1.AnyAllFilterLinkEntity = query_Or_Or1_solutioncomponent;
+        query_Or_Or1_solutioncomponent.LinkCriteria.AddCondition(SolutionComponent.LogicalNames.ComponentType, ConditionOperator.Equal, SolutionComponent.Options.ComponentType.SystemForm);  
+
+        var query_Or_Or1_solutioncomponent_And = new FilterExpression();
+        query_Or_Or1_solutioncomponent.LinkCriteria = query_Or_Or1_solutioncomponent_And;
+        var query_Or_Or1_solutioncomponent_And_solution = new LinkEntity(
+            SystemForm.EntityLogicalName,
+            Solution.EntityLogicalName,
+            SystemForm.LogicalNames.SolutionId,
+            Solution.LogicalNames.SolutionId,
+            JoinOperator.Any);
+        query_Or_Or1_solutioncomponent_And.AnyAllFilterLinkEntity = query_Or_Or1_solutioncomponent_And_solution;
+
+        foreach (var solutionName in configSolutions)
         {
-            solutionLink.LinkCriteria.AddCondition(Solution.LogicalNames.UniqueName, ConditionOperator.Equal,
-                configSolution);
+            query_Or_Or1_solutioncomponent_And_solution.LinkCriteria.AddCondition(Solution.LogicalNames.UniqueName, ConditionOperator.Equal, solutionName);
         }
 
-        var formIds = _connection.RetrieveMultiple(querySolutionForms).Entities
-            .Select(x => x.ToEntity<SolutionComponent>())
-            .Select(x => x.ObjectId);
-        var allForms = RetrieveFormsForEntity(entityLogicalName);
+        // System form linked through the entity component
+        var query_Or_Or2 = new FilterExpression(LogicalOperator.Or);
+        query_Or.AddFilter(query_Or_Or2);
+        var query_Or_Or2_entity = new LinkEntity(
+            SystemForm.EntityLogicalName,
+            "entity",
+            SystemForm.LogicalNames.ObjectTypeCode,
+            "objecttypecode",
+            JoinOperator.Any);
+        query_Or_Or2.AnyAllFilterLinkEntity = query_Or_Or2_entity;
 
-        return allForms.Entities.Where(e => formIds.Contains(e.Id))
-            .ToDictionary(
+        var query_Or_Or2_entity_And = new FilterExpression();
+        query_Or_Or2_entity.LinkCriteria = query_Or_Or2_entity_And;
+        var query_Or_Or2_entity_And_solutioncomponent = new LinkEntity(
+            SystemForm.EntityLogicalName,
+            SolutionComponent.EntityLogicalName,
+            "entityid",
+            SolutionComponent.LogicalNames.ObjectId,
+            JoinOperator.Any);
+        query_Or_Or2_entity_And.AnyAllFilterLinkEntity = query_Or_Or2_entity_And_solutioncomponent;
+
+        query_Or_Or2_entity_And_solutioncomponent.LinkCriteria.AddCondition(
+            SolutionComponent.LogicalNames.RootComponentBehavior,
+            ConditionOperator.Equal,
+            SolutionComponent.Options.RootComponentBehavior.IncludeSubcomponents);
+        var query_Or_Or2_entity_And_solutioncomponent_And = new FilterExpression();
+        query_Or_Or2_entity_And_solutioncomponent.LinkCriteria.AddFilter(query_Or_Or2_entity_And_solutioncomponent_And);
+        var query_Or_Or2_entity_And_solutioncomponent_And_solution = new LinkEntity(
+             SystemForm.EntityLogicalName,
+            Solution.EntityLogicalName,
+            SystemForm.LogicalNames.SolutionId,
+            Solution.LogicalNames.SolutionId,
+            JoinOperator.Any);
+        query_Or_Or2_entity_And_solutioncomponent_And.AnyAllFilterLinkEntity = query_Or_Or2_entity_And_solutioncomponent_And_solution;
+        foreach (var solutionName in configSolutions)
+        {
+            query_Or_Or2_entity_And_solutioncomponent_And_solution.LinkCriteria.AddCondition(Solution.LogicalNames.UniqueName, ConditionOperator.Equal, solutionName);
+        }
+
+        var allForms = _connection.RetrieveMultiple(querySystemForm).Entities.Select(x => x.ToEntity<SystemForm>());
+
+        return allForms.ToDictionary(
                 form =>
                     $"{form.GetAttributeValue<string>(SystemForm.LogicalNames.Name)}.{GetFormType(form.GetAttributeValue<OptionSetValue>(SystemForm.LogicalNames.Type).Value)}",
                 ParseForms);

--- a/tests/dgt.power.codegeneration.tests/TypescriptCommandTests.cs
+++ b/tests/dgt.power.codegeneration.tests/TypescriptCommandTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Metadata;
 using Spectre.Console;
 using Xunit.Abstractions;
+using FakeXrmEasy.Abstractions;
 #pragma warning disable CS8602
 
 namespace dgt.power.codegeneration.tests;
@@ -321,16 +322,17 @@ public class TypescriptCommandTests : CodeGenerationTestsBase<TypescriptCommand>
     public void ShouldGenerateFormsFromSolution()
     {
         var forms = GetForms();
-        var solution = new Solution(Guid.NewGuid())
+        var solution = new Solution
         {
+            Id = Guid.NewGuid(),
             UniqueName = "Test"
         };
-        var formComponent = new SolutionComponent(Guid.NewGuid())
+        var solutionFormComponent = new SolutionComponent
         {
+            Id = Guid.NewGuid(),
             [SolutionComponent.LogicalNames.SolutionId] = solution.ToEntityReference(),
             [SolutionComponent.LogicalNames.ObjectId] = forms.mainForm.Id,
-            [SolutionComponent.LogicalNames.ComponentType] =
-                new OptionSetValue(SolutionComponent.Options.ComponentType.SystemForm)
+            [SolutionComponent.LogicalNames.ComponentType] = new OptionSetValue(SolutionComponent.Options.ComponentType.SystemForm)
         };
         var config = new CodeGenerationConfig
         {
@@ -355,12 +357,21 @@ public class TypescriptCommandTests : CodeGenerationTestsBase<TypescriptCommand>
         var context = GetBuilder()
             .WithData(forms)
             .WithData(solution)
-            .WithData(formComponent)
+            .WithData(solutionFormComponent)            
+            .WithRelationship("system_form_entity", new XrmFakedRelationship
+            {
+                Entity1LogicalName = SystemForm.EntityLogicalName,
+                Entity1Attribute = SystemForm.LogicalNames.ObjectTypeCode,
+                Entity2LogicalName = "entity",
+                Entity2Attribute = "objecttypecode",
+                RelationshipType = XrmFakedRelationship.FakeRelationshipType.OneToMany
+            })
             .Build();
 
         context
             .Execute(args)
-            .Should().BeTrue();
+            .Should()
+            .BeTrue();
 
         var typescriptPath = GetArtifactPath($"{args.Folder}/{Folders.Typescript}");
 
@@ -582,24 +593,27 @@ public class TypescriptCommandTests : CodeGenerationTestsBase<TypescriptCommand>
 
     private (SystemForm mainForm, SystemForm quickCreate, SystemForm quickView) GetForms()
     {
-        var mainForm = new SystemForm(Guid.NewGuid())
+        var mainForm = new SystemForm
         {
+            Id = Guid.NewGuid(),
             Name = "Account",
             FormXml = GetResourceAsString("account.main.form.xml"),
             ObjectTypeCode = Account.EntityLogicalName,
             Type = new OptionSetValue(SystemForm.Options.Type.Main),
             FormActivationState = new OptionSetValue(SystemForm.Options.FormActivationState.Active)
         };
-        var quickCreateForm = new SystemForm(Guid.NewGuid())
+        var quickCreateForm = new SystemForm
         {
+            Id = Guid.NewGuid(),
             Name = "Account Quick Create",
             FormXml = GetResourceAsString("account.quick.create.form.xml"),
             ObjectTypeCode = Account.EntityLogicalName,
             Type = new OptionSetValue(SystemForm.Options.Type.QuickCreate),
             FormActivationState = new OptionSetValue(SystemForm.Options.FormActivationState.Active)
         };
-        var quickViewForm = new SystemForm(Guid.NewGuid())
+        var quickViewForm = new SystemForm
         {
+            Id = Guid.NewGuid(),
             Name = "App for Outlook Account Quick View",
             FormXml = GetResourceAsString("account.quick.view.form.xml"),
             ObjectTypeCode = Account.EntityLogicalName,


### PR DESCRIPTION
- Adapt the query for searching the SystemForms entities withing a solution:
     - It retrieves the SystemForm ones linked with the solution component (as today)
     - Also the ones linked through the entities that are linked to the solution (new)
 - Skip the bpf entities for the form generation as those will cause errors
 - Move code around to avoid error due sonar
     - Duplicated lines of code
     - Avoid cognitive complexity error in an existing function with extra `if`