### PR TITLE
Form template missed subgrid and other mapping corrections

### DIFF
--- a/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerLight.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerLight.cs
@@ -30,6 +30,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         _templateOptions.Filters.AddFilter("sanitize", CustomLiquidFilters.Sanitize);
         _templateOptions.Filters.AddFilter("unique", CustomLiquidFilters.Unique);
         _templateOptions.Filters.AddFilter("controltype",CustomLiquidFilters.Controltype);
+        _templateOptions.Filters.AddFilter("attributetype", CustomLiquidFilters.Attributetype);
         _templateOptions.Filters.AddFilter("localize", CustomLiquidFilters.Localize);
         _templateOptions.ValueConverters.Add(o => o is AttributeMetadata p ? new AttributeMetadataViewModel(p) : null);
         _templateOptions.ValueConverters.Add(o => o is OptionMetadata l ? new OptionMetadataViewModel(l) : null);
@@ -98,7 +99,6 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
             CreateFile(content, $"{metadata.LogicalName.ToLowerInvariant()}.{FileNames.Typescript.Entity}", args);
         }
     }
-
 
     public void GenerateEntityForms(CodeGenerationVerb args, CodeGenerationConfig config)
     {

--- a/src/modules/dgt.power.codegeneration/Templates/CustomLiquidFilters.cs
+++ b/src/modules/dgt.power.codegeneration/Templates/CustomLiquidFilters.cs
@@ -51,13 +51,13 @@ public static class CustomLiquidFilters
     public static ValueTask<FluidValue> Controltype(FluidValue input, FilterArguments arguments,
         TemplateContext context)
     {
-        var contextId = context.GetHashCode();
-        var scope = arguments.At(0).ToObjectValue();
-        var value = input.ToStringValue();
+        return new StringValue(GetAttributeByLogicalName(input, arguments, context).DefinitelyTypedControlType);
+    }
 
-        var attr = new List<AttributeMetadataViewModel>(((object[])scope).Cast<AttributeMetadataViewModel>());
-
-        return new StringValue(attr.Single(s => s.LogicalName == value).DefinitelyTypedControlType);
+    public static ValueTask<FluidValue> Attributetype(FluidValue input, FilterArguments arguments,
+       TemplateContext context)
+    {
+        return new StringValue(GetAttributeByLogicalName(input, arguments, context).DefinitelyTypedAttributeType);
     }
 
     public static ValueTask<FluidValue> Localize(FluidValue input, FilterArguments arguments, TemplateContext context)
@@ -68,5 +68,16 @@ public static class CustomLiquidFilters
         return languageCode == null
             ? new StringValue(label.GetLocalizedLabel())
             : new StringValue(label.GetLocalizedLabel(Convert.ToInt32(languageCode, CultureInfo.InvariantCulture)));
+    }
+
+    private static AttributeMetadataViewModel GetAttributeByLogicalName(FluidValue input, FilterArguments arguments,
+       TemplateContext context)
+    {
+        var contextId = context.GetHashCode();
+        var scope = arguments.At(0).ToObjectValue();
+        var value = input.ToStringValue();
+
+        var attr = new List<AttributeMetadataViewModel>(((object[])scope).Cast<AttributeMetadataViewModel>());
+        return attr.Single(s => s.LogicalName == value);
     }
 }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/EntityForm.liquid
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/EntityForm.liquid
@@ -11,15 +11,45 @@ declare namespace XrmTable.{{ SchemaName | camelcase }} {
     export interface {{ FormName }}FormContext extends Xrm.FormContext {
         getAttribute():  Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>[];
         getControl(): Xrm.Controls.Control[];
-    {% for attr in Attributes  %}
-        getAttribute(name: "{{ attr.LogicalName }}"): {{ attr.DefinitelyTypedAttributeType  }};
-        getControl(name: "{{ attr.LogicalName }}"): {{ attr.DefinitelyTypedControlType  }};
-    {% endfor %}
+        {% for field in FormDetail.Fields  %}
+        getAttribute(name: "{{ field }}"): {{ field | attributetype: Attributes }};
+        getControl(name: "{{ field }}"): {{ field | controltype: Attributes }};
+        {% endfor %}
+        getAttribute(name: string): Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues> | null;
+        getControl(name: string): Xrm.Controls.Control | null;
+        {% for subgrid in FormDetail.Grids %}
+        getControl(name: "{{ subgrid }}"): Xrm.Controls.GridControl;
+        {% endfor %}
         ui: {{ FormName }}Ui;
+        data: {{ FormName }}Data;
     }
 
     export interface {{ FormName  }}Ui extends Xrm.Ui {
         tabs: {{ FormName }}Tabs;
+        controls: {{ FormName }}Controls;
+    }
+
+    export interface {{ FormName }}Data extends Xrm.Data {
+        entity: {{ FormName }}Entity;
+    }
+
+    export interface {{ FormName }}Entity extends Xrm.Entity {
+        attributes: {{ FormName }}Attributes;
+    }
+
+    export interface {{ FormName }}Attributes extends Xrm.Collection.ItemCollection<Xrm.Attributes.Attribute<Xrm.Attributes.Attribute.AttributeValues>> {
+        {% for field in FormDetail.Fields  %}
+        get(name: "{{ field }}"): {{ field | attributetype: Attributes }};
+        {% endfor %}
+        get(name: string): Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues> | null;
+        get(delegate?: MatchingDelegate<Xrm.Attributes.Attribute<Xrm.Attributes.Attribute.AttributeValues>>): Xrm.Attributes.Attribute<Xrm.Attributes.Attribute.AttributeValues>[];
+    }
+
+    export interface {{ FormName }}Controls extends Xrm.Collection.ItemCollection<Xrm.Controls.Control> {
+        {% for field in FormDetail.Fields  %}
+        get(name: "{{ field }}"): {{ field | controltype: Attributes }};
+        {% endfor %}
+        get(name: string): Xrm.Controls.Control | null;
     }
 
     {% for tab in FormDetail.TabDetails  %}{%- assign TabName = tab.Name  | sanitize | camelcase | unique: "T" -%}
@@ -33,7 +63,8 @@ declare namespace XrmTable.{{ SchemaName | camelcase }} {
     export interface {{ FormName }}{{ TabName }} extends Xrm.Controls.Tab {
         sections: {{ FormName }}{{ TabName }}Sections;
     }
-        {% for section in tab.Detail.Sections  %}{%- assign SectionName = section.Name  | sanitize | camelcase %}
+
+    {% for section in tab.Detail.Sections  %}{%- assign SectionName = section.Name  | sanitize | camelcase %}
     export interface {{ FormName }}{{ TabName }}{{ SectionName }}Section extends Xrm.Controls.Section {
         controls: {{ FormName }}{{ TabName }}{{ SectionName }}ControlCollection;
     }
@@ -44,15 +75,13 @@ declare namespace XrmTable.{{ SchemaName | camelcase }} {
         {%- endfor %}
         get(delegate?: Xrm.Collection.MatchingDelegate<Xrm.Controls.Control>): Xrm.Controls.Control[];
     }
-        {% endfor %}
+    {% endfor %}
 
-                        export interface EventEmbeddedMainTab2Sections extends Xrm.Collection.ItemCollection<Xrm.Controls.Section> {
-                            get(itemName: "tab_2_section_1"): EventEmbeddedMainTab2Tab2Section1Section;
-                            get(itemName: "tab_2_section_2"): EventEmbeddedMainTab2Tab2Section2Section;
-                            get(itemName: "tab_2_section_4"): EventEmbeddedMainTab2Tab2Section4Section;
-                            get(delegate?: Xrm.Collection.MatchingDelegate<Xrm.Controls.Section>): Xrm.Controls.Section[];
-
-                                }
-
+    export interface EventEmbeddedMainTab2Sections extends Xrm.Collection.ItemCollection<Xrm.Controls.Section> {
+        get(itemName: "tab_2_section_1"): EventEmbeddedMainTab2Tab2Section1Section;
+        get(itemName: "tab_2_section_2"): EventEmbeddedMainTab2Tab2Section2Section;
+        get(itemName: "tab_2_section_4"): EventEmbeddedMainTab2Tab2Section4Section;
+        get(delegate?: Xrm.Collection.MatchingDelegate<Xrm.Controls.Section>): Xrm.Controls.Section[];
+    }
     {% endfor %}
 }


### PR DESCRIPTION
- The form template in context interface is missing the loop over subgrids to provide subgrid control getters in form context
- The form template in context interface loops over entity attributes for attribute/control creation which creates control/attribute getters for every control in the entity even when is not placed in the form.
    - Change the loop to loop over Form fields instead
    - Create auxiliary Liquid filter function to get the attribute type out of the list with the field name
- Add extra functions to the form context interface template
    - getcontrol/getattribute(name: string): This allows to work for when doing loops over with field names
- Add data element to the form context interface template
     -  We then allow the named getters for the attributes
- Add controls element inside the ui template element
     - We then allow the named getters for the form controls 