### PR TITLE
feat(tsl): extra adaptations for ts custom api generation

### DIFF
--- a/src/modules/dgt.power.codegeneration/Constants/FileNames.cs
+++ b/src/modules/dgt.power.codegeneration/Constants/FileNames.cs
@@ -15,15 +15,16 @@ public static class FileNames
 
     public static class Typescript
     {
-        public static string Model => "model";
-        public static string Services => "services";
-        public static string Webapi => "webapi";
-        public static string Utils => "utils";
-        public static string Odata => "odata";
+        public static string CustomApi => "customapi";
         public static string Entity => "entity";
         public static string EntityRef => "entityref";
         public static string Form => "form";
-        public static string SdkMessageNames => "sdkmessagenames";
+        public static string Model => "model";
+        public static string Odata => "odata";
         public static string OptionSetValues => "optionsetvalues";
+        public static string SdkMessageNames => "sdkmessagenames";
+        public static string Services => "services";
+        public static string Utils => "utils";
+        public static string Webapi => "webapi";
     }
 }

--- a/src/modules/dgt.power.codegeneration/Generators/Contracts/ITypescriptGenerator.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Contracts/ITypescriptGenerator.cs
@@ -2,7 +2,6 @@
 // DIGITALL Nature licenses this file to you under the Microsoft Public License.
 
 using dgt.power.codegeneration.Base;
-using dgt.power.codegeneration.Templates.ts;
 
 namespace dgt.power.codegeneration.Generators.Contracts;
 
@@ -16,4 +15,5 @@ public interface ITypescriptGenerator
     void GenerateSdkMessages(CodeGenerationVerb args, CodeGenerationConfig config);
     void GenerateOptionSets(CodeGenerationVerb args, CodeGenerationConfig config);
     void GenerateBusinessProcessFlowsFull(CodeGenerationVerb args, CodeGenerationConfig config);
+    void GenerateCustomApis(CodeGenerationVerb arg, CodeGenerationConfig config);
 }

--- a/src/modules/dgt.power.codegeneration/Generators/TypescriptGeneratorFascade.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/TypescriptGeneratorFascade.cs
@@ -6,7 +6,6 @@ using dgt.power.codegeneration.Base;
 using dgt.power.codegeneration.Generators.Contracts;
 using dgt.power.codegeneration.Generators.Worker;
 using dgt.power.codegeneration.Services.Contracts;
-using dgt.power.codegeneration.Templates.ts;
 
 namespace dgt.power.codegeneration.Generators;
 
@@ -111,6 +110,15 @@ public class TypescriptGeneratorFascade : ITypescriptGeneratorFascade
         Debug.Assert(_generator != null, nameof(_generator) + " != null");
 
         _generator.GenerateBusinessProcessFlowsFull(args, config);
+    }
+
+    public void GenerateCustomApis(CodeGenerationVerb args, CodeGenerationConfig config)
+    {
+        Debug.Assert(args != null, nameof(args) + " != null");
+        Debug.Assert(config != null, nameof(config) + " != null");
+        Debug.Assert(_generator != null, nameof(_generator) + " != null");
+
+        _generator.GenerateCustomApis(args, config);
     }
 
     public void SetGenerationVersion(TypescriptGeneratorVersion generatorVersion)

--- a/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorker.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorker.cs
@@ -2,6 +2,8 @@
 // DIGITALL Nature licenses this file to you under the Microsoft Public License.
 
 using System.Diagnostics;
+using System.Reflection;
+using System.Xml.Linq;
 using dgt.power.codegeneration.Base;
 using dgt.power.codegeneration.Constants;
 using Spectre.Console;
@@ -32,8 +34,23 @@ public abstract class TypescriptGeneratorWorker
         file.Write(content);
     }
 
+    public void CopyTemplateFileContent(CodeGenerationVerb args, string templateFileName, string extension)
+    {
+        // Ensure that the template and args are not null
+        Debug.Assert(templateFileName != null, nameof(templateFileName) + " != null");
+        Debug.Assert(templateFileName != null, nameof(templateFileName) + " != null");
+        Debug.Assert(args != null, nameof(args) + " != null");
+
+        var reader = new StreamReader(Assembly.GetCallingAssembly()
+            .GetManifestResourceStream($"dgt.power.codegeneration.Templates.tsl.{templateFileName}.{extension}")!);
+
+        var content = reader.ReadToEnd();
+
+        CreateFile(content, templateFileName, args);
+    }
+
     /// <summary>
-    ///     Prepares the directory for code generation.
+    /// Prepares the directory for code generation.
     /// </summary>
     /// <param name="args">The code generation arguments.</param>
     public void PrepareDirectory(CodeGenerationVerb args)

--- a/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerFull.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerFull.cs
@@ -261,4 +261,8 @@ public class TypescriptGeneratorWorkerFull(IMetadataService metadataService)
     }
 
     #endregion
+
+    #region NotImplemented
+    public void GenerateCustomApis(CodeGenerationVerb arg, CodeGenerationConfig config) => throw new NotImplementedException();
+    #endregion
 }

--- a/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerLight.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerLight.cs
@@ -39,6 +39,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         _templateOptions.ValueConverters.Add(o => o is OptionMetadata l ? new OptionMetadataViewModel(l) : null);
         _templateOptions.ValueConverters.Add(o => o is BpfControlDetail r ? new BpfControlViewModel(r): null);
         _templateOptions.ValueConverters.Add(o => o is FormXmlControlData r ? new FormControlViewModel(r) : null);
+        _templateOptions.ValueConverters.Add(o => o is WfParameter wp ? new CustomApiParameterViewModel(wp) : null);
         _templateOptions.ValueConverters.Add(o => o is KeyValuePair<string, List<Option>> k ? new OptionViewModel(k) : null);
         _templateOptions.ValueConverters.Add(o => o is KeyValuePair<string, SectionDetail> td ? new SectionDetailsViewModel(td) : null);
         _templateOptions.MemberAccessStrategy.Register<AttributeMetadataViewModel>();
@@ -50,6 +51,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         _templateOptions.MemberAccessStrategy.Register<FormAttributeData>();
         _templateOptions.MemberAccessStrategy.Register<FormControlViewModel>();
         _templateOptions.MemberAccessStrategy.Register<BpfControlViewModel>();
+        _templateOptions.MemberAccessStrategy.Register<CustomApiParameterViewModel>();
         _templateOptions.MemberAccessStrategy.Register<TabDetail>();
         _templateOptions.MemberAccessStrategy.Register<SectionDetailsViewModel>();
         _templateOptions.MemberAccessStrategy.Register<SectionDetail>();
@@ -179,6 +181,43 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
     }
 
     /// <summary>
+    /// Generates Custom Apis type for code generation
+    /// </summary>
+    /// <param name="args"></param>
+    /// <param name="config"></param>
+    public void GenerateCustomApis(CodeGenerationVerb args, CodeGenerationConfig config)
+    {
+        // Check if the arguments and configuration are not null
+        Debug.Assert(args != null, nameof(args) + " != null");
+        Debug.Assert(config != null, nameof(config) + " != null");
+
+        // Check if SDK messages should be suppressed
+        if (config.CustomAPIs == null || config.CustomAPIs.Length < 1)
+        {
+            return;
+        }
+
+       var customApis = _metadataService.RetrieveCustomAPIs(config);
+        CopyTemplateFileContent(args, "xrm_webapi_ext", "d.ts");
+       var liquidTemplate = InitializeLiquidTemplate("CustomApi.liquid");
+
+        foreach (var customApi in customApis)
+        {
+            var viewModel = new CustomApiViewModel()
+            {
+                Name = customApi.LogicalName,
+                InParameters = customApi.InParameters,
+                OutParameters = customApi.OutParameters
+            };
+            var context = new TemplateContext(viewModel, _templateOptions);
+            var content = liquidTemplate.Render(context);
+
+            var customApiName = $"{Formatter.Sanitize(customApi.LogicalName.ToLowerInvariant().Trim(), true).Replace(' ', '_')}.{FileNames.Typescript.CustomApi}";
+            CreateFile(content, customApiName, args);
+        }
+    }
+
+    /// <summary>
     ///     Generates option sets based on the provided arguments and configuration
     /// </summary>
     /// <param name="args">The code generation verb</param>
@@ -304,7 +343,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
             .Where(a => !a.LogicalName.Contains("entityimage"))
             .Where(a => a.AttributeType != AttributeTypeCode.ManagedProperty)
             .OrderBy(a => a.LogicalName).ToList();
-    }  
+    }
 
     #endregion
 

--- a/src/modules/dgt.power.codegeneration/Logic/TypescriptCommand.cs
+++ b/src/modules/dgt.power.codegeneration/Logic/TypescriptCommand.cs
@@ -3,11 +3,9 @@
 
 using System.Diagnostics;
 using dgt.power.codegeneration.Base;
-using dgt.power.codegeneration.Generators;
 using dgt.power.codegeneration.Generators.Contracts;
 using dgt.power.common;
 using Microsoft.Xrm.Sdk;
-using Spectre.Console.Cli;
 
 namespace dgt.power.codegeneration.Logic;
 
@@ -43,6 +41,10 @@ public class TypescriptCommand : PowerLogic<CodeGenerationVerb>
             _generatorFascade.GenerateBusinessProcessFlowsFull(args, config);
         }
 
+        if (config.TypescriptGeneratorVersion == TypescriptGeneratorVersion.Light)
+        {
+            _generatorFascade.GenerateCustomApis(args, config);
+        }
 
         return true;
     }

--- a/src/modules/dgt.power.codegeneration/Model/WfParameter.cs
+++ b/src/modules/dgt.power.codegeneration/Model/WfParameter.cs
@@ -10,4 +10,7 @@ public class WfParameter
     public string? Type { get; set; }
     public string? Description { get; set; }
     public string? Entityname { get; set; }
+    public required bool IsOptional { get; set; }
+
+    public required bool IsOutput { get; set; }
 }

--- a/src/modules/dgt.power.codegeneration/Services/MetadataService.cs
+++ b/src/modules/dgt.power.codegeneration/Services/MetadataService.cs
@@ -16,6 +16,7 @@ using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
 using Spectre.Console;
+using static dgt.power.dataverse.CustomAPIRequestParameter.Options;
 
 namespace dgt.power.codegeneration.Services;
 
@@ -205,7 +206,9 @@ public class MetadataService : IMetadataService
                     UniqueName = ext.Name,
                     Description = ext.Description,
                     Entityname = ext.EntityName,
-                    Type = ext.Type!.Split(':')[1].TrimEnd(')')
+                    Type = ext.Type!.Split(':')[1].TrimEnd(')'),
+                    IsOptional = false, // Not used for actions,
+                    IsOutput = ext.Direction == "Output" ? true : false,
                 };
 
                 switch (ext.Direction)
@@ -280,7 +283,9 @@ public class MetadataService : IMetadataService
                         UniqueName = "Target",
                         Description = "bound Target",
                         Entityname = target,
-                        Type = nameof(EntityReference)
+                        Type = nameof(EntityReference),
+                        IsOptional = false, // Bound parameters will be required parameters
+                        IsOutput = false,
                     });
             }
 
@@ -292,7 +297,8 @@ public class MetadataService : IMetadataService
                     CustomAPIRequestParameter.LogicalNames.UniqueName,
                     CustomAPIRequestParameter.LogicalNames.Name,
                     CustomAPIRequestParameter.LogicalNames.Description,
-                    CustomAPIRequestParameter.LogicalNames.Type
+                    CustomAPIRequestParameter.LogicalNames.Type,
+                    CustomAPIRequestParameter.LogicalNames.IsOptional
                 ),
                 Criteria = new FilterExpression(LogicalOperator.And)
                 {
@@ -311,11 +317,13 @@ public class MetadataService : IMetadataService
                 ia.InParameters.Add(
                     new WfParameter
                     {
-                        Name = (string)inparam["name"],
-                        UniqueName = (string)inparam["uniquename"],
-                        Description = inparam.GetAttributeValue<string>("description"),
+                        Name = (string)inparam[CustomAPIRequestParameter.LogicalNames.Name],
+                        UniqueName = (string)inparam[CustomAPIRequestParameter.LogicalNames.UniqueName],
+                        Description = inparam.GetAttributeValue<string>(CustomAPIRequestParameter.LogicalNames.Description),
                         Entityname = "",
-                        Type = type
+                        Type = type,
+                        IsOptional = (bool?)inparam[CustomAPIRequestParameter.LogicalNames.IsOptional] ?? false,
+                        IsOutput = false,
                     });
             }
 
@@ -347,11 +355,13 @@ public class MetadataService : IMetadataService
                 ia.OutParameters.Add(
                     new WfParameter
                     {
-                        Name = (string)outparam["name"],
-                        UniqueName = (string)outparam["uniquename"],
-                        Description = outparam.GetAttributeValue<string>("description"),
+                        Name = (string)outparam[CustomAPIResponseProperty.LogicalNames.Name],
+                        UniqueName = (string)outparam[CustomAPIResponseProperty.LogicalNames.UniqueName],
+                        Description = outparam.GetAttributeValue<string>(CustomAPIResponseProperty.LogicalNames.Description),
                         Entityname = "",
-                        Type = type
+                        Type = type,
+                        IsOptional = true, // assume all responses can be optional
+                        IsOutput = true,
                     });
             }
 

--- a/src/modules/dgt.power.codegeneration/Templates/CustomLiquidFilters.cs
+++ b/src/modules/dgt.power.codegeneration/Templates/CustomLiquidFilters.cs
@@ -4,7 +4,6 @@
 using System.Globalization;
 using dgt.power.codegeneration.Extensions;
 using dgt.power.codegeneration.Logic;
-using dgt.power.codegeneration.Model;
 using dgt.power.codegeneration.Templates.tsl.ViewModels;
 using Fluid;
 using Fluid.Values;

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/CustomApi.liquid
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/CustomApi.liquid
@@ -1,0 +1,21 @@
+﻿{%- assign CustomApiName = Name  | sanitize | camelcase -%}
+
+declare namespace XrmCustomApi.{{ CustomApiName }} {
+    export const enum CustomApiEnums {
+        LogicalName = "{{ Name }}"
+    }
+    
+    {%- if InParameters.size > 0 %}
+    export interface Request extends XrmWebApi.ExecuteRequest {
+        {% for inParameter in InParameters  %}
+        {{ inParameter.ParameterName }}{%- if inParameter.IsOptional %}?{%- endif %}: {{ inParameter.ParameterType }};{% endfor %}
+    }
+    {%- endif %}
+
+    {%- if OutParameters.size > 0 %}
+    export interface Response {
+        {% for outParameter in OutParameters  %}
+        {{ outParameter.ParameterName }}{%- if outParameter.IsOptional %}?{%- endif %}: {{ outParameter.ParameterType }};{% endfor %}
+    }
+    {%- endif %}
+}

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/ViewModels/CustomApiParameterViewModel.cs
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/ViewModels/CustomApiParameterViewModel.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) DIGITALL Nature. All rights reserved
+// DIGITALL Nature licenses this file to you under the Microsoft Public License.
+
+using dgt.power.codegeneration.Model;
+
+namespace dgt.power.codegeneration.Templates.tsl.ViewModels
+{
+    public class CustomApiParameterViewModel
+    {
+        public string ParameterName { get; init; }
+        public string ParameterType { get; init; }
+        public bool IsOptional { get; init; }
+
+        public CustomApiParameterViewModel(WfParameter parameter)
+        {
+            ParameterName = parameter.UniqueName ?? string.Empty; // Unique name is a required param in custom api req/responses            
+            IsOptional = parameter.IsOptional;
+            if (parameter.UniqueName == "Target")
+            {
+                ParameterName = "entity";
+                ParameterType = "Xrm.LookupValue";
+                return;
+            }
+            switch (parameter.Type)
+            {
+                case "bool":
+                    ParameterType = "boolean";
+                    break;
+                case "DateTime":
+                    ParameterType = "Date";
+                    break;
+                case "decimal":
+                case "Money":
+                case "float":
+                case "int":
+                    ParameterType = "number";
+                    break;
+                case "Guid":
+                    if (parameter.IsOutput)
+                    {
+                        ParameterType = "string";
+                        break;
+                    }
+                    ParameterType = "XrmWebApi.WebApiGuidProperty";
+                    break;
+                case "EntityReference":
+                    ParameterType = "Xrm.LookupValue";
+                    break;
+                case "EntityCollection":
+                    ParameterType = "EntityCollection"; // TOBE CLARIFIED
+                    break;
+                case "Entity":
+                    ParameterType = "Entity"; // TOBE CLARIFIED
+                    break;
+                case "OptionSetValue":
+                    ParameterType = "OptionSetValue"; // TOBE CLARIFIED
+                    break;
+                default:
+                    ParameterType = parameter.Type ?? "string";
+                    break;
+            }
+        }
+    }
+}

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/ViewModels/CustomApiViewModel.cs
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/ViewModels/CustomApiViewModel.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) DIGITALL Nature. All rights reserved
+// DIGITALL Nature licenses this file to you under the Microsoft Public License.
+
+using dgt.power.codegeneration.Model;
+
+namespace dgt.power.codegeneration.Templates.tsl.ViewModels
+{
+    public class CustomApiViewModel
+    {
+        public required string Name { get; set; }
+        public required List<WfParameter> InParameters { get; set; }
+
+        public required List<WfParameter> OutParameters { get; set; }
+    }
+}

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_webapi_ext.d.ts
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_webapi_ext.d.ts
@@ -1,0 +1,68 @@
+﻿declare namespace XrmWebApi {
+    export interface WebApiMetadataObject {
+        /**
+         * The name of the bound parameter for the action or function to execute.
+         */
+        boundParameter?: null | undefined | "entity";
+
+        /**
+         * Name of the action, function, or one of the following values if you are executing a CRUD request: "Create", "Retrieve", "Update", "Delete" or action name string.
+         */
+        operationName?: "Create" | "Retrieve" | "Update" | "Delete" | string;
+
+        /**
+         * Indicates the type of operation you are executing
+         */
+        operationType?: WebApiOperationType;
+
+        /**
+         * The metadata for parameter types
+         */
+        parameterTypes: { [key: string]: WebApiParameterType };
+    }
+
+    export interface WebApiParameterType {
+        /**
+         * The fully qualified name of the parameter type.
+         */
+        typeName: string;
+
+        /**
+         * The metadata for enum types.
+         */
+        enumProperties?: WebApiEnumProperty[];
+
+        /**
+         * The category of the parameter type.
+         */
+        structuralProperty: WebApiStructuralProperty;
+    }
+
+    export interface WebApiEnumProperty {
+        name: string;
+        value: number;
+    }
+
+    export interface WebApiGuidProperty {
+        guid: string;
+    }
+
+    export interface ExecuteRequest {
+        getMetadata(): WebApiMetadataObject;
+    }
+
+    export const enum WebApiOperationType {
+        Action = 0,
+        Function = 1,
+        CRUD = 2,
+    }
+
+    export const enum WebApiStructuralProperty {
+        Unknown = 0,
+        PrimitiveType = 1,
+        ComplexType = 2,
+        EnumerationType = 3,
+        Collection = 4,
+        EntityType = 5,
+    }
+}

--- a/src/modules/dgt.power.codegeneration/dgt.power.codegeneration.csproj
+++ b/src/modules/dgt.power.codegeneration/dgt.power.codegeneration.csproj
@@ -218,6 +218,8 @@
     <EmbeddedResource Include="Templates\tsl\EntityForm.liquid" />
     <None Remove="Templates\tsl\Entity.liquid" />
     <EmbeddedResource Include="Templates\tsl\Entity.liquid" />
+    <EmbeddedResource Include="Templates\tsl\CustomApi.liquid" />
+    <EmbeddedResource Include="Templates\tsl\xrm_webapi_ext.d.ts" />
   </ItemGroup>
 
 </Project>

--- a/tests/dgt.power.codegeneration.tests/DotNetCommandTests.cs
+++ b/tests/dgt.power.codegeneration.tests/DotNetCommandTests.cs
@@ -210,7 +210,8 @@ public class DotNetCommandTests : CodeGenerationTestsBase<DotNetCommand>
             Name = "String Parameter",
             Description = "String",
             Type = new OptionSetValue(CustomAPIRequestParameter.Options.Type.String),
-            CustomAPIId = customApi.ToEntityReference()
+            CustomAPIId = customApi.ToEntityReference(),
+            IsOptional = false,
         };
         var customApiResponseProperty = new CustomAPIResponseProperty(Guid.NewGuid())
         {


### PR DESCRIPTION
- Added logic to generate custom api request/response typing
- The @types/xrm does not contain any types for the online execute call: 
    - ```execute(request: any): Async.PromiseLike<ExecuteResponse>;```
- Create a set of base typyings file in the templates `xrm_webapi_ext.d.ts` and copy the contents of that file in the target folder, the custom api request/responses will extend this object
- Mapping for some of the inputs types must be later checked with futher details