### PR TITLE
feat(tsl): adapt logic so ts files have a folder structure

### DIFF
--- a/src/modules/dgt.power.codegeneration/Constants/Folders.cs
+++ b/src/modules/dgt.power.codegeneration/Constants/Folders.cs
@@ -9,6 +9,8 @@ public static class Folders
     public const string Model = "Model";
 #pragma warning restore S2339
     public static string Typescript => "TypeScript";
+    public static string TypescriptEntityForms => "EntityForms";
+    public static string TypescriptCustomApis => "CustomApi";
     public static string Metadata => "MetaData";
     public static string DotNet => "DotNet";
 }

--- a/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorker.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorker.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Reflection;
-using System.Xml.Linq;
 using dgt.power.codegeneration.Base;
 using dgt.power.codegeneration.Constants;
 using Spectre.Console;
@@ -12,20 +11,32 @@ namespace dgt.power.codegeneration.Generators.Worker;
 
 public abstract class TypescriptGeneratorWorker
 {
+
+    private const string NOT_NULL = "!= null";
     /// <summary>
     ///     Creates a TypeScript file with the specified content and name in the target directory.
     /// </summary>
     /// <param name="content">The content to be written into the file.</param>
     /// <param name="name">The name of the file to be created.</param>
     /// <param name="args">The code generation arguments, including target directory and folder configuration.</param>
-    public void CreateFile(string content, string name, CodeGenerationVerb args)
+    /// <param name="outputPath">Additional path in the output ts script folder</param>
+    public void CreateFile(string content, string name, CodeGenerationVerb args, string[]? outputPath = null)
     {
         // Ensure that the template and args are not null
-        Debug.Assert(content != null, nameof(content) + " != null");
-        Debug.Assert(args != null, nameof(args) + " != null");
-
+        Debug.Assert(content != null, $"{nameof(content)} {NOT_NULL}");
+        Debug.Assert(args != null, $"{nameof(args)} {NOT_NULL}");
+        Debug.Assert(name != null, $"{nameof(name)} + { NOT_NULL}");
         // Combine the target directory, folder, and file name to create the full path
-        var path = Path.Combine(args.TargetDirectory, args.Folder, Folders.Typescript, $"{name}.d.ts");
+        var path = Path.Combine([
+            args.TargetDirectory,
+            args.Folder,
+            Folders.Typescript,
+            ..(outputPath ?? ([])),
+            $"{name}.d.ts"
+        ]);
+
+        // Create directly if needed
+        CreateDirectoryWhenNeeded(Path.GetDirectoryName(path));
         // Create a text file at the specified path
         using var file = File.CreateText(path);
         // Print a message indicating the file creation
@@ -37,9 +48,9 @@ public abstract class TypescriptGeneratorWorker
     public void CopyTemplateFileContent(CodeGenerationVerb args, string templateFileName, string extension)
     {
         // Ensure that the template and args are not null
-        Debug.Assert(templateFileName != null, nameof(templateFileName) + " != null");
-        Debug.Assert(templateFileName != null, nameof(templateFileName) + " != null");
-        Debug.Assert(args != null, nameof(args) + " != null");
+        Debug.Assert(templateFileName != null, $"{nameof(templateFileName)} {NOT_NULL}");
+        Debug.Assert(args != null, $"{nameof(args)} {NOT_NULL}");
+        Debug.Assert(extension != null, $"{nameof(extension)} {NOT_NULL}");
 
         var reader = new StreamReader(Assembly.GetCallingAssembly()
             .GetManifestResourceStream($"dgt.power.codegeneration.Templates.tsl.{templateFileName}.{extension}")!);
@@ -56,29 +67,43 @@ public abstract class TypescriptGeneratorWorker
     public void PrepareDirectory(CodeGenerationVerb args)
     {
         // Ensure that the arguments are not null
-        Debug.Assert(args != null, nameof(args) + " != null");
+        Debug.Assert(args != null, $"{nameof(args)} {NOT_NULL}");
 
         // Create the main folder if it doesn't exist
         var mainFolderPath = Path.Combine(args.TargetDirectory, args.Folder);
-        if (!Directory.Exists(mainFolderPath))
-        {
-            Directory.CreateDirectory(mainFolderPath);
-        }
+        CreateDirectoryWhenNeeded(mainFolderPath);
 
         // Create the Typescript folder if it doesn't exist
         var typescriptFolderPath = Path.Combine(mainFolderPath, Folders.Typescript);
-        if (!Directory.Exists(typescriptFolderPath))
-        {
-            Directory.CreateDirectory(typescriptFolderPath);
-        }
-        else
-        {
-            // Delete all .ts files in the Typescript folder
-            var typescriptFiles = Directory.GetFiles(typescriptFolderPath, "*.ts");
-            foreach (var file in typescriptFiles)
+        if (!CreateDirectoryWhenNeeded(typescriptFolderPath)) {
+            // Delete all files and folders in the directory file
+            var directory = new DirectoryInfo(typescriptFolderPath);
+            // Delete files in ts folder
+            foreach (var file in directory.GetFiles())
             {
-                File.Delete(file);
+                file.Delete();
+            }
+            // Delete all subfolders
+            foreach (var dir in directory.GetDirectories())
+            {
+                dir.Delete(true);
             }
         }
+    }
+
+    /// <summary>
+    /// Auxiliary function given a path creates missed directory folders and returns true, false when folder already exists
+    /// </summary>
+    /// <param name="path"></param>
+    /// <returns></returns>
+    private static bool CreateDirectoryWhenNeeded(string? directoryPath)
+    {
+        Debug.Assert(directoryPath != null, $"{nameof(directoryPath)} {NOT_NULL}");
+        if (!Directory.Exists(directoryPath))
+        {
+            Directory.CreateDirectory(directoryPath);
+            return true;
+        }
+        return false;
     }
 }

--- a/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerLight.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerLight.cs
@@ -103,8 +103,9 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
             };
             var context = new TemplateContext(viewModel, _templateOptions);
             var content = liquidTemplate.Render(context);
+            var formEntityName = metadata.LogicalName.ToLowerInvariant().Trim();
 
-            CreateFile(content, $"{metadata.LogicalName.ToLowerInvariant().Trim()}.{FileNames.Typescript.Entity}", args);
+            CreateFile(content, $"{formEntityName}.{FileNames.Typescript.Entity}", args, GetEntityFolderName(metadata.LogicalName));
         }
     }
 
@@ -213,7 +214,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
             var content = liquidTemplate.Render(context);
 
             var customApiName = $"{Formatter.Sanitize(customApi.LogicalName.ToLowerInvariant().Trim(), true).Replace(' ', '_')}.{FileNames.Typescript.CustomApi}";
-            CreateFile(content, customApiName, args);
+            CreateFile(content, customApiName, args, [Folders.TypescriptCustomApis]);
         }
     }
 
@@ -281,7 +282,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         };
         var context = new TemplateContext(viewModel, _templateOptions);
         var content = liquidTemplate.Render(context);
-        CreateFile(content, form, args);
+        CreateFile(content, form, args, GetEntityFolderName(metadata.LogicalName));
     }
 
     private Dictionary<string, SortedSet<BpfControlDetail>> GetCompleteEntityBpfControlList(CodeGenerationConfig config)
@@ -343,6 +344,17 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
             .Where(a => !a.LogicalName.Contains("entityimage"))
             .Where(a => a.AttributeType != AttributeTypeCode.ManagedProperty)
             .OrderBy(a => a.LogicalName).ToList();
+    }
+
+    /// <summary>
+    /// Given the entity logical name calculates a folder name for the given ts files
+    /// </summary>
+    /// <param name="entityLogicalName"></param>
+    /// <returns></returns>
+    private static string[] GetEntityFolderName(string entityLogicalName)
+    {
+        var formEntityName = entityLogicalName.ToLowerInvariant().Trim();
+        return [Folders.TypescriptEntityForms, Formatter.CamelCase(Formatter.Sanitize(formEntityName))];
     }
 
     #endregion


### PR DESCRIPTION
- Add an ouput folder structure for the typescript folder for a more organized output:
     - CustomApi: It will hold all the custom api files in specific folder
     - EntityForms: Holds inside a folder per entity named after the entity, each entity folder will hold entity d.ts file and related entity form d.ts files
     - sdkmessages, options and webapi-ext will go directly in the typescript folder