### PR TITLE
Feature/ts generation more hierarchical namespaces for better dev experience

### DIFF
--- a/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerLight.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerLight.cs
@@ -1,7 +1,6 @@
 // Copyright (c) DIGITALL Nature. All rights reserved
 // DIGITALL Nature licenses this file to you under the Microsoft Public License.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using dgt.power.codegeneration.Base;
@@ -276,7 +275,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         {
             Name = formname,
             FormDetail = formDetail.Value,
-            SchemaName = metadata.SchemaName,
+            EntitySchemaName = metadata.SchemaName,
             Attributes = FilterEntityMetadataAttributes(metadata),
             BpfControls = formDetail.Value.FormType == SystemForm.Options.Type.QuickViewForm ? [] : bpfControls.ToList(),
         };

--- a/src/modules/dgt.power.codegeneration/Model/FormDetail.cs
+++ b/src/modules/dgt.power.codegeneration/Model/FormDetail.cs
@@ -5,18 +5,22 @@ namespace dgt.power.codegeneration.Model;
 
 public class FormDetail
 {
-    public SortedSet<string> HeaderControlFields { get; }
-    public SortedSet<string> Grids { get; }
     public SortedSet<FormAttributeData> Attributes { get; }
     public SortedSet<FormXmlControlData> FormControls { get; }
-    public SortedSet<TabDetail> TabDetails { get; }
+    public string FormUniqueName { get; set; }
     public int FormType { get; set; }
+    public string FormTypeName { get; set; }
+    public SortedSet<string> Grids { get; }
+    public SortedSet<string> HeaderControlFields { get; }
+    public SortedSet<TabDetail> TabDetails { get; }
     public SortedDictionary<string, List<string>> Tabs { get; }
 
     public FormDetail()
     {
         Attributes = [];
         FormControls = [];
+        FormUniqueName = string.Empty;
+        FormTypeName = string.Empty;
         Grids = [];
         HeaderControlFields = [];
         TabDetails = [];

--- a/src/modules/dgt.power.codegeneration/Services/FormParser.cs
+++ b/src/modules/dgt.power.codegeneration/Services/FormParser.cs
@@ -12,15 +12,19 @@ namespace dgt.power.codegeneration.Services
 {
     public static class FormParser
     {
-        public static FormDetail ParseForms(Entity form, SortedSet<BpfControlDetail>? bpfControls)
+        public static FormDetail ParseForm(Entity form, string formUniqueName, SortedSet<BpfControlDetail>? bpfControls)
         {
             var formxml = form.GetAttributeValue<string>(SystemForm.LogicalNames.FormXml);
-            var formType = form.GetAttributeValue<OptionSetValue>(SystemForm.LogicalNames.Type);
+            var formType = form.GetAttributeValue<OptionSetValue>(SystemForm.LogicalNames.Type).Value;
             var doc = new XmlDocument();
             doc.LoadXml(formxml);
 
-            var formDetail = new FormDetail();
-            formDetail.FormType = form.GetAttributeValue<OptionSetValue>(SystemForm.LogicalNames.Type).Value;
+            var formDetail = new FormDetail()
+            {
+                FormType = formType,
+                FormTypeName = FormatFormType(GetFormType(formType)),
+                FormUniqueName = formUniqueName,
+            };
 
             var tabs = doc.SelectNodes("/form/tabs/tab[*]");
             if (tabs == null)
@@ -252,10 +256,10 @@ namespace dgt.power.codegeneration.Services
         /// <param name="formDetail"></param>
         /// <param name="formType"></param>
         /// <param name="bpfControls"></param>
-        private static void MapBpfControlsAttributesIntoFormDetail(FormDetail formDetail, OptionSetValue? formType, SortedSet<BpfControlDetail>? bpfControls)
+        private static void MapBpfControlsAttributesIntoFormDetail(FormDetail formDetail, int formType, SortedSet<BpfControlDetail>? bpfControls)
         {
             // Exclude header process controls in case of quick view forms
-            if (bpfControls != null && formType?.Value != SystemForm.Options.Type.QuickViewForm)
+            if (bpfControls != null && formType != SystemForm.Options.Type.QuickViewForm)
             {
                 var bfControlFieldNames = bpfControls
                     .Where(bpfControl => !formDetail.Attributes.Any(x => x.DataFieldName == bpfControl.DataFieldName))
@@ -306,6 +310,24 @@ namespace dgt.power.codegeneration.Services
                 return string.Empty;
             }
             return Regex.Replace(classId.ToUpperInvariant(), "[{}]", "", RegexOptions.NonBacktracking);
+        }
+
+        public static string FormatFormType(string formType)
+        {
+             return formType
+                .Replace("main", "Main")
+                .Replace("quickview", "Quick View")
+                .Replace("quickcreate", "Quick Create");
+        }
+
+        public static string GetFormType(int type)
+        {
+            return type switch
+            {
+                2 => "main",
+                6 => "quickview",
+                _ => "quickcreate"
+            };
         }
     }
 }

--- a/src/modules/dgt.power.codegeneration/Services/MetadataService.cs
+++ b/src/modules/dgt.power.codegeneration/Services/MetadataService.cs
@@ -16,7 +16,6 @@ using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
 using Spectre.Console;
-using static dgt.power.dataverse.CustomAPIRequestParameter.Options;
 
 namespace dgt.power.codegeneration.Services;
 
@@ -109,12 +108,7 @@ public class MetadataService : IMetadataService
                         ConditionOperator.Equal, uniqueName)
                 }
             }
-        }).Entities.SingleOrDefault()?.ToEntity<Solution>();
-
-    private static string WildCardToRegular(string value)
-    {
-        return "^" + Regex.Escape(value).Replace("\\?", ".").Replace("\\*", ".*") + "$";
-    }
+        }).Entities.SingleOrDefault()?.ToEntity<Solution>();   
 
     public IEnumerable<WfAction> RetrieveActions(CodeGenerationConfig config)
     {
@@ -371,25 +365,6 @@ public class MetadataService : IMetadataService
         return result;
     }
 
-    private static string GetParamType(int paramType) =>
-        paramType switch
-        {
-            0 => "bool",
-            1 => "DateTime",
-            2 => "decimal",
-            3 => "Entity",
-            4 => "EntityCollection",
-            5 => "EntityReference",
-            6 => "float",
-            7 => "int",
-            8 => "Money",
-            9 => "OptionSetValue",
-            10 => "string",
-            11 => "string[]",
-            12 => "Guid",
-            _ => "object"
-        };
-
     public IEnumerable<(string Name, string Message)> RetrieveSdkMessageNames(CodeGenerationConfig config)
     {
         var result = new List<(string Name, string Message)>();
@@ -622,7 +597,6 @@ public class MetadataService : IMetadataService
             .ThenBy(x => x.DataFieldName)
             .ToList();
     }
-
     public List<Tuple<string, string, List<Guid>>> RetrieveBusinessProcessFlowStages(Guid processId)
     {
         var result = new List<Tuple<string, string, List<Guid>>>();
@@ -754,33 +728,30 @@ public class MetadataService : IMetadataService
             query_Or_Or2_entity_And_solutioncomponent_And_solution.LinkCriteria.AddCondition(Solution.LogicalNames.UniqueName, ConditionOperator.Equal, solutionName);
         }
 
-        var allForms = _connection.RetrieveMultiple(querySystemForm).Entities.Select(x => x.ToEntity<SystemForm>());
+        var systemForms = _connection.RetrieveMultiple(querySystemForm);
 
-        return allForms.ToDictionary(
-                form =>
-                    $"{Unique(form.GetAttributeValue<string>(SystemForm.LogicalNames.Name).Trim(), entityLogicalName)}.{GetFormType(form.GetAttributeValue<OptionSetValue>(SystemForm.LogicalNames.Type).Value)}",
-                (form) => FormParser.ParseForms(form, bpfControls));
+        return ParseSystemFormsCollectionToFormDetails(systemForms, entityLogicalName, bpfControls);
     }
 
     public Dictionary<string, FormDetail> RetrieveFormsDetails(string entityLogicalName, SortedSet<BpfControlDetail>? bpfControls)
     {
-        var allForms = RetrieveFormsForEntity(entityLogicalName);
-        return allForms.Entities
-            .ToDictionary(
-                form =>
-                    $"{Unique(form.GetAttributeValue<string>(SystemForm.LogicalNames.Name).Trim(), entityLogicalName)}.{GetFormType(form.GetAttributeValue<OptionSetValue>(SystemForm.LogicalNames.Type).Value)}",
-                (form) => FormParser.ParseForms(form, bpfControls));
+        var systemForms = RetrieveFormsForEntity(entityLogicalName);
+        return ParseSystemFormsCollectionToFormDetails(systemForms, entityLogicalName, bpfControls);
     }
 
-    private static string GetFormType(int type)
+    private Dictionary<string, FormDetail> ParseSystemFormsCollectionToFormDetails(EntityCollection forms, string entityLogicalName, SortedSet<BpfControlDetail>? bpfControls)
     {
-        return type switch
+        var allForms = forms.Entities.Select(x => x.ToEntity<SystemForm>());
+        return allForms.Select(form =>
         {
-            2 => "main",
-            6 => "quickview",
-            _ => "quickcreate"
-        };
-    }   
+            // Made unique name with scope by entity and form type
+            var formScope = $"{entityLogicalName}.{form.Type?.Value}";
+            return FormParser.ParseForm(form,
+                Unique(form.GetAttributeValue<string>(SystemForm.LogicalNames.Name).Trim(), formScope),
+                bpfControls);
+        })
+       .ToDictionary(formDetail => $"{formDetail.FormUniqueName}.{FormParser.GetFormType(formDetail.FormType)}", formDetail => formDetail);
+    }    
 
     private EntityCollection RetrieveFormsForEntity(string logicalName)
     {
@@ -803,7 +774,7 @@ public class MetadataService : IMetadataService
         return _connection.RetrieveMultiple(query);
     }
 
-    internal string Unique(string value, string scope)
+    private string Unique(string value, string scope)
     {
         if (!_usedTokens.ContainsKey(scope)) _usedTokens.Add(scope, new List<string>());
 
@@ -813,4 +784,28 @@ public class MetadataService : IMetadataService
         _usedTokens[scope].Add(value);
         return value;
     }
+
+    private static string WildCardToRegular(string value)
+    {
+        return "^" + Regex.Escape(value).Replace("\\?", ".").Replace("\\*", ".*") + "$";
+    }
+
+    private static string GetParamType(int paramType) =>
+        paramType switch
+        {
+            0 => "bool",
+            1 => "DateTime",
+            2 => "decimal",
+            3 => "Entity",
+            4 => "EntityCollection",
+            5 => "EntityReference",
+            6 => "float",
+            7 => "int",
+            8 => "Money",
+            9 => "OptionSetValue",
+            10 => "string",
+            11 => "string[]",
+            12 => "Guid",
+            _ => "object"
+        };
 }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/Entity.liquid
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/Entity.liquid
@@ -53,16 +53,18 @@ declare namespace XrmTable.{{ SchemaName | camelcase }} {
     {%- endfor %}
     }
 
-    export const enum Attributes {
+    export const enum LogicalNames {
     {%- for attr in Attributes  %}
         {{ attr.SchemaName | sanitize | camelcase | unique: "A"  }} =  "{{ attr.LogicalName }}",
     {%- endfor %}
     }
-{% for attr in EnumAttributes  %}
-    export const enum {{ attr.SchemaName | sanitize | camelcase | unique: "O"  }} {
-    {%- for option in attr.Options  %}
-        {{ option.Label | localize: LanguageCode | sanitize | camelcase   }} =  {{ option.Value }},
-    {%- endfor %}
+
+    namespace Options {
+    {% for attr in EnumAttributes  %}
+        export const enum {{ attr.SchemaName | sanitize | camelcase | unique: "O"  }} {
+        {%- for option in attr.Options  %}
+            {{ option.Label | localize: LanguageCode | sanitize | camelcase   }} =  {{ option.Value }},
+        {%- endfor %}
+        }{% endfor %}
     }
-{% endfor %}
 }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/EntityForm.liquid
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/EntityForm.liquid
@@ -1,4 +1,5 @@
-{%- assign FormName = Name  | sanitize | camelcase -%}
+{%- assign FormName = FormDetail.FormUniqueName  | sanitize | camelcase -%}
+{%- assign FormType = FormDetail.FormTypeName  | sanitize | camelcase -%}
 /* eslint-disable */
 
 declare namespace Xrm.Events {
@@ -7,73 +8,75 @@ declare namespace Xrm.Events {
     }
 }
 
-declare namespace XrmTable.{{ SchemaName | camelcase }} {
-    export interface {{ FormName }}FormContext extends Xrm.FormContext {
-        getAttribute(name: string): undefined;
-        {% for attribute in FormDetail.Attributes  %}
-        getAttribute(name: "{{ attribute.DataFieldName }}"): {{ attribute.DataFieldName | attributetype: Attributes }}{%- if attribute.IsOptionalAttribute %} | null{%- endif %};{% endfor %}
-        getControl(name: string): undefined;
-        {% for formControl in FormDetail.FormControls  %}
-        getControl(name: "{{ formControl.ControlName }}"): {{ formControl.DefinitelyTypedControlType }};{% endfor %}
-        {% for headerField in FormDetail.HeaderControlFields  %}
-        getControl(name: "header_{{ headerField }}"): {{ headerField | controltype: Attributes }};{% endfor %}
-        {% for bpfControl in BpfControls %}
-        getControl(name: "header_process_{{ bpfControl.DataFieldName }}"): {{ bpfControl.DefinitelyTypedControlType }} | null;{% endfor %}
-        {% for subgrid in FormDetail.Grids %}
-        getControl(name: "{{ subgrid }}"): Xrm.Controls.GridControl;{% endfor %}
-        ui: {{ FormName }}Ui;
-        data: {{ FormName }}Data;
-    }
+declare namespace XrmForm.{{ EntitySchemaName | camelcase }} {
+    namespace {{ FormType }}.{{ FormName }} {
+        export interface FormContext extends Xrm.FormContext {
+            getAttribute(name: string): undefined;
+            {% for attribute in FormDetail.Attributes  %}
+            getAttribute(name: "{{ attribute.DataFieldName }}"): {{ attribute.DataFieldName | attributetype: Attributes }}{%- if attribute.IsOptionalAttribute %} | null{%- endif %};{% endfor %}
+            getControl(name: string): undefined;
+            {% for formControl in FormDetail.FormControls  %}
+            getControl(name: "{{ formControl.ControlName }}"): {{ formControl.DefinitelyTypedControlType }};{% endfor %}
+            {% for headerField in FormDetail.HeaderControlFields  %}
+            getControl(name: "header_{{ headerField }}"): {{ headerField | controltype: Attributes }};{% endfor %}
+            {% for bpfControl in BpfControls %}
+            getControl(name: "header_process_{{ bpfControl.DataFieldName }}"): {{ bpfControl.DefinitelyTypedControlType }} | null;{% endfor %}
+            {% for subgrid in FormDetail.Grids %}
+            getControl(name: "{{ subgrid }}"): Xrm.Controls.GridControl;{% endfor %}
+            ui: Ui;
+            data: Data;
+        }
 
-    export interface {{ FormName  }}Ui extends Xrm.Ui {
-        tabs: {{ FormName }}Tabs;
-        controls: {{ FormName }}Controls;
-    }
+        export interface Ui extends Xrm.Ui {
+            tabs: Tabs;
+            controls: Controls;
+        }
 
-    export interface {{ FormName }}Data extends Xrm.Data {
-        entity: {{ FormName }}Entity;
-    }
+        export interface Data extends Xrm.Data {
+            entity: Entity;
+        }
 
-    export interface {{ FormName }}Entity extends Xrm.Entity {
-        attributes: {{ FormName }}Attributes;
-    }
+        export interface Entity extends Xrm.Entity {
+            attributes: Attributes;
+        }
 
-    export interface {{ FormName }}Attributes extends Xrm.Collection.ItemCollection<Xrm.Attributes.Attribute<Xrm.Attributes.Attribute.AttributeValues>> {
-        {% for attribute in FormDetail.Attributes  %}
-        get(name: "{{ attribute.DataFieldName }}"): {{ attribute.DataFieldName | attributetype: Attributes }};{% endfor %}
-        get(name: string): Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues> | undefined;
-        get(delegate?: MatchingDelegate<Xrm.Attributes.Attribute<Xrm.Attributes.Attribute.AttributeValues>>): Xrm.Attributes.Attribute<Xrm.Attributes.Attribute.AttributeValues>[];
-    }
+        export interface Attributes extends Xrm.Collection.ItemCollection<Xrm.Attributes.Attribute<Xrm.Attributes.Attribute.AttributeValues>> {
+            {% for attribute in FormDetail.Attributes  %}
+            get(name: "{{ attribute.DataFieldName }}"): {{ attribute.DataFieldName | attributetype: Attributes }};{% endfor %}
+            get(name: string): Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues> | undefined;
+            get(delegate?: MatchingDelegate<Xrm.Attributes.Attribute<Xrm.Attributes.Attribute.AttributeValues>>): Xrm.Attributes.Attribute<Xrm.Attributes.Attribute.AttributeValues>[];
+        }
 
-    export interface {{ FormName }}Controls extends Xrm.Collection.ItemCollection<Xrm.Controls.Control> {
-        {% for formControl in FormDetail.FormControls  %}
-        get(name: "{{ formControl.ControlName }}"): {{ formControl.DefinitelyTypedControlType }};{% endfor %}
-        get(name: string): Xrm.Controls.Control | undefined;
-        get(delegate?: MatchingDelegate<Xrm.Controls.Control>): Xrm.Controls.Control[];
-    }
+        export interface Controls extends Xrm.Collection.ItemCollection<Xrm.Controls.Control> {
+            {% for formControl in FormDetail.FormControls  %}
+            get(name: "{{ formControl.ControlName }}"): {{ formControl.DefinitelyTypedControlType }};{% endfor %}
+            get(name: string): Xrm.Controls.Control | undefined;
+            get(delegate?: MatchingDelegate<Xrm.Controls.Control>): Xrm.Controls.Control[];
+        }
 
-    export interface {{ FormName }}Tabs extends Xrm.Collection.ItemCollection<Xrm.Controls.Tab> {
+        export interface Tabs extends Xrm.Collection.ItemCollection<Xrm.Controls.Tab> {
+            {% for tab in FormDetail.TabDetails  %}{%- assign TabName = tab.TabName | sanitize | camelcase -%}
+            get(itemName: "{{ tab.TabName }}"): {{ TabName }};
+            {% endfor %}
+            get(name: string): undefined;
+            get(delegate?: Xrm.Collection.MatchingDelegate<Xrm.Controls.Tab>): Xrm.Controls.Tab[];
+        }
         {% for tab in FormDetail.TabDetails  %}{%- assign TabName = tab.TabName | sanitize | camelcase -%}
-        get(itemName: "{{ tab.TabName }}"): {{ FormName }}{{ TabName }};
-        {% endfor %}
-        get(name: string): undefined;
-        get(delegate?: Xrm.Collection.MatchingDelegate<Xrm.Controls.Tab>): Xrm.Controls.Tab[];
-    }
-    {% for tab in FormDetail.TabDetails  %}{%- assign TabName = tab.TabName | sanitize | camelcase -%}
-    export interface {{ FormName }}{{ TabName }} extends Xrm.Controls.Tab {
-        sections: {{ FormName }}{{ TabName }}Sections;
-    }
+        export interface {{ TabName }} extends Xrm.Controls.Tab {
+            sections: {{ TabName }}Sections;
+        }
 
-    export interface {{ FormName }}{{ TabName }}Sections extends Xrm.Collection.ItemCollection<Xrm.Controls.Section> {
-        {% for section in tab.Sections  %}
-        {%- assign SectionName = section.SectionName | sanitize | camelcase %}get(name: "{{ section.SectionName }}"): {{ FormName }}{{ TabName }}{{ SectionName }};{%- endfor %}
-        get(name: string): undefined;
+        export interface {{ TabName }}Sections extends Xrm.Collection.ItemCollection<Xrm.Controls.Section> {
+            {% for section in tab.Sections  %}
+            {%- assign SectionName = section.SectionName | sanitize | camelcase %}get(name: "{{ section.SectionName }}"): {{ TabName }}{{ SectionName }};{%- endfor %}
+            get(name: string): undefined;
+        }
+        {% for section in tab.Sections  %}{%- assign SectionName = section.SectionName | sanitize | camelcase %}
+        export interface {{ TabName }}{{ SectionName }} extends Xrm.Controls.Section {
+            {%- for controlName in section.ControlNames %}
+            get(name: "{{ controlName }}"): {{ controlName | formControlType: FormDetail.FormControls }}; {%- endfor %}
+            get(name: string): undefined;
+        }
+        {% endfor %}{% endfor %}
     }
-    {% for section in tab.Sections  %}{%- assign SectionName = section.SectionName | sanitize | camelcase %}
-    export interface {{ FormName }}{{ TabName }}{{ SectionName }} extends Xrm.Controls.Section {
-        {%- for controlName in section.ControlNames %}
-        get(name: "{{ controlName }}"): {{ controlName | formControlType: FormDetail.FormControls }}; {%- endfor %}
-        get(name: string): undefined;
-    }
-    {% endfor %}{% endfor %}
 }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/ViewModels/FormViewModel.cs
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/ViewModels/FormViewModel.cs
@@ -8,12 +8,9 @@ namespace dgt.power.codegeneration.Templates.tsl.ViewModels;
 
 public record FormViewModel
 {
-    public required string SchemaName { get; init; }
-
     public required List<AttributeMetadata> Attributes { get; init; }
-
-    public required string Name { get; init; }
-    public required FormDetail FormDetail { get; init; }
-
     public required List<BpfControlDetail> BpfControls { get; init; }
+    public required string EntitySchemaName { get; init; }
+    public required FormDetail FormDetail { get; init; }
+    public required string Name { get; init; }
 }


### PR DESCRIPTION
- Correct the form name uniqueness handling as it adds extra "_" when not needed, group the form uniqueness not only by entity but by entity and form type 
- Modify the namespace names for the form and entity interfaces to have a hierarchical namespaces that makes an easier development handling (no super long dropdowns in the intellisense). Try to make the TS namespaces similar to the backend ones
- For the entities forms the form related typings will hang of a XrmForm namespace following the next name pattern
     - **XrmForm.[EntityName].[FormType].[FormName]**: Where Form type is Main/QuickForm/QuickView...
         - e.g. *XrmForm.Account.Main.Information.FormContext* -> to access the form context interface
- For the entities:
    - **XrmTable.[EntityName].DTO**
    - **XrmTable.[EntityName].Options**
        - All option set enums there
    - **XrmTable.[EntityName].LogicalNames**
        - Holds the names of the entity attributes