### PR TITLE
feat(tsl): include formid in the generated classes for frontend logic…

### DIFF
--- a/src/modules/dgt.power.codegeneration/Model/FormDetail.cs
+++ b/src/modules/dgt.power.codegeneration/Model/FormDetail.cs
@@ -7,6 +7,7 @@ public class FormDetail
 {
     public SortedSet<FormAttributeData> Attributes { get; }
     public SortedSet<FormXmlControlData> FormControls { get; }
+    public string FormId { get; set; }
     public string FormUniqueName { get; set; }
     public int FormType { get; set; }
     public string FormTypeName { get; set; }

--- a/src/modules/dgt.power.codegeneration/Services/FormParser.cs
+++ b/src/modules/dgt.power.codegeneration/Services/FormParser.cs
@@ -15,6 +15,7 @@ namespace dgt.power.codegeneration.Services
     {
         public static FormDetail ParseForm(Entity form, string formUniqueName, SortedSet<BpfControlDetail>? bpfControls)
         {
+            var formId = form.GetAttributeValue<Guid>(SystemForm.LogicalNames.FormId).ToString();
             var formxml = form.GetAttributeValue<string>(SystemForm.LogicalNames.FormXml);
             var formType = form.GetAttributeValue<OptionSetValue>(SystemForm.LogicalNames.Type).Value;
             var doc = new XmlDocument();
@@ -25,6 +26,7 @@ namespace dgt.power.codegeneration.Services
                 FormType = formType,
                 FormTypeName = FormatFormType(GetFormType(formType)),
                 FormUniqueName = formUniqueName,
+                FormId = formId,
             };
 
             var tabs = doc.SelectNodes("/form/tabs/tab[*]");
@@ -44,6 +46,7 @@ namespace dgt.power.codegeneration.Services
 
             // Map bp process controls that will be mapped as "header_process_"
             MapBpfControlsAttributesIntoFormDetail(formDetail, formType, bpfControls);
+
             return formDetail;
         }
 

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/EntityForm.liquid
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/EntityForm.liquid
@@ -12,6 +12,9 @@ declare namespace Xrm.Events {
 
 declare namespace XrmForm.{{ EntitySchemaName | camelcase }} {
     namespace {{ FormType }}.{{ FormName }} {
+        export const enum FormData {
+            FormId = "{{ FormDetail.FormId }}",
+        }
         export interface FormContext extends Xrm.FormContext {
             getAttribute<T extends Xrm.Attributes.Attribute>(name: string): T | null;
             getAttribute(name: string): Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues> | null;

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/ViewModels/AttributeMetadataViewModel.cs
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/ViewModels/AttributeMetadataViewModel.cs
@@ -7,21 +7,14 @@ namespace dgt.power.codegeneration.Templates.tsl.ViewModels;
 
 public record AttributeMetadataViewModel
 {
-    public string NativeType { get; set; }
-
-    public OptionMetadataCollection Options { get; set; }
-
-    public string SchemaName { get; set; }
-
     public string DefinitelyType { get; set; }
-
-    public string DefinitelyTypedControlType { get; set; }
-
-    public string LogicalName { get; set; }
-
     public string DefinitelyTypedAttributeType { get; set; }
-
+    public string DefinitelyTypedControlType { get; set; }
     public bool IsPrimaryId { get; set; }
+    public string LogicalName { get; set; }
+    public string NativeType { get; set; }
+    public OptionMetadataCollection Options { get; set; }
+    public string SchemaName { get; set; }
 
     public AttributeMetadataViewModel(AttributeMetadata attributeMetadata) => ToViewModel(attributeMetadata);
 
@@ -69,18 +62,15 @@ public record AttributeMetadataViewModel
                 DefinitelyTypedControlType = "Xrm.Controls.NumberControl";
                 DefinitelyType = "BigInt";
                 NativeType = "number";
-                break;
+                break;                
             case AttributeTypeCode.Customer:
-                DefinitelyTypedAttributeType = "Xrm.Attributes.LookupAttribute";
-                DefinitelyTypedControlType = "Xrm.Controls.LookupControl";
-                DefinitelyType = "Customer";
-                break;
             case AttributeTypeCode.PartyList:
             case AttributeTypeCode.Owner:
             case AttributeTypeCode.Lookup:
                 DefinitelyTypedAttributeType = "Xrm.Attributes.LookupAttribute";
                 DefinitelyTypedControlType = "Xrm.Controls.LookupControl";
                 DefinitelyType = "Lookup";
+                NativeType = "any";
                 break;
             case AttributeTypeCode.String:
             case AttributeTypeCode.Memo:
@@ -135,19 +125,15 @@ public record AttributeMetadataViewModel
     }
 
 
-    private string GetDateTimeType(DateTimeAttributeMetadata? attr)
+    private static string GetDateTimeType(DateTimeAttributeMetadata? attr)
     {
-        if (attr.DateTimeBehavior == DateTimeBehavior.DateOnly)
-        {
-            if (attr.Format == DateTimeFormat.DateOnly)
-            {
-                return "DateOnly:DateOnly";
-            }
 
-            return "DateOnly:UserLocal";
+        if (attr?.DateTimeBehavior == DateTimeBehavior.DateOnly && attr?.Format == DateTimeFormat.DateOnly)
+        {
+            return "DateOnly:DateOnly";
         }
 
-        if (attr.DateTimeBehavior == DateTimeBehavior.TimeZoneIndependent)
+        if (attr?.DateTimeBehavior == DateTimeBehavior.TimeZoneIndependent)
         {
             return "DateOnly:TimeZoneIndependent";
         }


### PR DESCRIPTION
- Include formid in the generated classes for frontend logic in the generated files instead of harcoding it in the web resources. 
    - Examples:
         - openForm: Hide or select some value programmatically
         - **openForm**: Pass the form id to _openForm_ function and open specific form 