### PR TITLE
feat(tsl): improve test helper class

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     },
     "packageManager": "pnpm@10.6.4+sha512.da3d715bfd22a9a105e6e8088cfc7826699332ded60c423b14ec613a185f1602206702ff0fe4c438cb15c979081ce4cb02568e364b15174503a63c7a8e2a5f6c",
     "dependencies": {
+        "@odata/parser": "^0.2.14",
         "xrm-mock": "^3.6.2"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@odata/parser':
+        specifier: ^0.2.14
+        version: 0.2.14
+      xrm-mock:
+        specifier: ^3.6.2
+        version: 3.6.2
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.3.1
@@ -140,6 +147,9 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
+  '@newdash/newdash@5.23.1':
+    resolution: {integrity: sha512-yVMMjSNKUyUC9dXM+h3M7D3e+MwKWeK6dqn0K3OkAIFkHY9/+9dXLncBipa2P3nQ7SJJlFaa0Gwx1OioXbJFhg==}
+
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
     engines: {node: '>= 20'}
@@ -187,6 +197,14 @@ packages:
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@odata/metadata@0.2.8':
+    resolution: {integrity: sha512-7oJW1gGEYmuJ/deCnVIncsp4oH1dR7xszAMp4KWyGtZ/t78MrwYs4FIsm2/OlBKL3F/zI8wNTMt0TU6/KFm5Kw==}
+    engines: {node: '>=10'}
+
+  '@odata/parser@0.2.14':
+    resolution: {integrity: sha512-aio+Ok2WbEY+foVe9YL+ondDsXqbk8UEFYCJSmDvbELLDv1WDjY8tx96wm1ASZXIbD3PIMDw+KYbjiLn2aYdxg==}
+    engines: {node: '>=10'}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -257,14 +275,47 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/conventional-commits-parser@5.0.2':
     resolution: {integrity: sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==}
+
+  '@types/express-serve-static-core@4.19.8':
+    resolution: {integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==}
+
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
   '@types/node@25.0.3':
     resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/qs@6.14.0':
+    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -1210,6 +1261,9 @@ packages:
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
+  reflect-metadata@0.1.14:
+    resolution: {integrity: sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==}
+
   registry-auth-token@5.1.0:
     resolution: {integrity: sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==}
     engines: {node: '>=14'}
@@ -1501,6 +1555,9 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  xrm-mock@3.6.2:
+    resolution: {integrity: sha512-QvojP2zERu1Xhtd/nVOibo5NJFrlo/iOj7h6e+E9p+g02YxX7W7I/t0sTm/oULlchtjyzZ/sPJygK3zXKEDRtA==}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -1691,6 +1748,8 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
+  '@newdash/newdash@5.23.1': {}
+
   '@octokit/auth-token@6.0.0': {}
 
   '@octokit/core@7.0.6':
@@ -1749,6 +1808,17 @@ snapshots:
   '@octokit/types@16.0.0':
     dependencies:
       '@octokit/openapi-types': 27.0.0
+
+  '@odata/metadata@0.2.8':
+    dependencies:
+      '@newdash/newdash': 5.23.1
+      '@types/express': 4.17.25
+      reflect-metadata: 0.1.14
+
+  '@odata/parser@0.2.14':
+    dependencies:
+      '@newdash/newdash': 5.23.1
+      '@odata/metadata': 0.2.8
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -1866,15 +1936,61 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 25.0.3
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 25.0.3
+
   '@types/conventional-commits-parser@5.0.2':
     dependencies:
       '@types/node': 25.0.3
+
+  '@types/express-serve-static-core@4.19.8':
+    dependencies:
+      '@types/node': 25.0.3
+      '@types/qs': 6.14.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@4.17.25':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 4.19.8
+      '@types/qs': 6.14.0
+      '@types/serve-static': 1.15.10
+
+  '@types/http-errors@2.0.5': {}
+
+  '@types/mime@1.3.5': {}
 
   '@types/node@25.0.3':
     dependencies:
       undici-types: 7.16.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/qs@6.14.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@0.17.6':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 25.0.3
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 25.0.3
+
+  '@types/serve-static@1.15.10':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 25.0.3
+      '@types/send': 0.17.6
 
   JSONStream@1.3.5:
     dependencies:
@@ -2695,6 +2811,8 @@ snapshots:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
+  reflect-metadata@0.1.14: {}
+
   registry-auth-token@5.1.0:
     dependencies:
       '@pnpm/npm-conf': 2.3.1
@@ -2966,6 +3084,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.1.2
+
+  xrm-mock@3.6.2: {}
 
   xtend@4.0.2: {}
 

--- a/src/dgt.power.common/dgt.power.common.csproj
+++ b/src/dgt.power.common/dgt.power.common.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="9.0.11" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.10" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/dgt.power/dgt.power.csproj
+++ b/src/dgt.power/dgt.power.csproj
@@ -29,13 +29,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.10" />
-    <PackageReference Include="NuGet.Protocol" Version="7.0.1" />
+    <PackageReference Include="NuGet.Protocol" Version="7.3.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/dgt.power/packages.lock.json
+++ b/src/dgt.power/packages.lock.json
@@ -4,35 +4,35 @@
     "net8.0": {
       "Microsoft.Extensions.Configuration.CommandLine": {
         "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "s5cxcdtIig66YT3J+7iHflMuorznK8kXuwBBPHMp4KImx5ZGE3FRa1Nj9fI/xMwFV+KzUMjqZ2MhOedPH8LiBQ==",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "qVytXuCHQCIJcOsJJnp+1mNCAtiWuLqI0qhCcByFuyxDifthefEWX3fVAXbaxn1lDP2iR1KH44Oq7tvmT7dBHg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.1",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1"
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3"
         }
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "csD8Eps3HQ3yc0x6NhgTV+aIFKSs3qVlVCtFnMHz/JOjnv7eEj/qSXKXiK9LzBzB1qSfAVqFnB5iaX2nUmagIQ==",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "jBm6bpc5OM2VHM/QYVUyD78xweFzble6UsIt7GUnQAwCm07hktFaUBtRfO7viLGg5qPbc4ByteNB7DeVAYNSfA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.1",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1"
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3"
         }
       },
       "Microsoft.Extensions.Configuration.Json": {
         "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "0zW3eYBJlRctmgqk5s0kFIi5o5y2g80mvGCD8bkYxREPQlKUnr0ndU/Sop+UDIhyWN0fIi4RW63vo7BKTi7ncA==",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "mGGMOA9nkET8OVsQfS41o66eWkckBzNHJK6+5VbLQ2YdyqKphcv27uDZxLf4exSl+5QxLnHkN+W/4qEDgyvCPA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.1",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.1",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
-          "System.Text.Json": "10.0.1"
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3",
+          "System.Text.Json": "10.0.3"
         }
       },
       "Microsoft.PowerPlatform.Dataverse.Client": {
@@ -69,21 +69,21 @@
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "requested": "[10.0.103, )",
+        "resolved": "10.0.103",
+        "contentHash": "qZk7r40ftpZY+/sO019sgWAWfNqC2CLSspDdAxNYCJU/bCi/8jVwvOMjzb/d5gjCRNzQ4OCYgBfhdpQyVwLTyw==",
         "dependencies": {
-          "Microsoft.Build.Tasks.Git": "8.0.0",
-          "Microsoft.SourceLink.Common": "8.0.0"
+          "Microsoft.Build.Tasks.Git": "10.0.103",
+          "Microsoft.SourceLink.Common": "10.0.103"
         }
       },
       "NuGet.Protocol": {
         "type": "Direct",
-        "requested": "[7.0.1, )",
-        "resolved": "7.0.1",
-        "contentHash": "bYPzTqgOSsXV8AxXXFCCPtAtlxwph0DVtdM8AlaKTGLClHDx7VAlL4cCIcVl2iEzQuG1uC79SvzllvKi1grcNw==",
+        "requested": "[7.3.0, )",
+        "resolved": "7.3.0",
+        "contentHash": "QWx4Fko06Act+gVhB9UUc8Hzt0fnA8qQhD5SFn/xEis2ZZVzmatHmMdsc0SV7tyvCUlfG8DzQzYLF7fF4LvTyA==",
         "dependencies": {
-          "NuGet.Packaging": "7.0.1"
+          "NuGet.Packaging": "7.3.0"
         }
       },
       "Spectre.Console.Cli": {
@@ -176,8 +176,8 @@
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+        "resolved": "10.0.103",
+        "contentHash": "QoiCMcPuxC6eqRQmrmF9zBY96ejIznXtve/lJJbonGD9I5Aygf2AUCOWslGiCEtBbfWRSuUnepBjuuVOdAl5ag=="
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
@@ -259,19 +259,19 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
+        "resolved": "10.0.3",
+        "contentHash": "H1Cjv2xmm7O3iAGmFTcnSM0ZhLQ/7SqefmAvSJoT1PbXoxeYc2fo0mCLn2JlVbr9E6YpoU9q/o0fI9neDJB0xQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
-          "Microsoft.Extensions.Primitives": "10.0.1"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Primitives": "10.0.3"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "kPlU11hql+L9RjrN2N9/0GcRcRcZrNFlLLjadasFWeBORT6pL6OE+RYRk90GGCyVGSxTK+e1/f3dsMj5zpFFiQ==",
+        "resolved": "10.0.3",
+        "contentHash": "xVDHL0+SIgemfh95fTO9cGLe17TWv/ZP0n7m01z8X6pzt2DmQpucioWR/mYZA1sRlkWnkXzfl0JweLNWmE9WMg==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.1"
+          "Microsoft.Extensions.Primitives": "10.0.3"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
@@ -284,14 +284,14 @@
       },
       "Microsoft.Extensions.Configuration.FileExtensions": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "N/6GiwiZFCBFZDk3vg1PhHW3zMqqu5WWpmeZAA9VTXv7Q8pr8NZR/EQsH0DjzqydDksJtY6EQBsu81d5okQOlA==",
+        "resolved": "10.0.3",
+        "contentHash": "/MLsBbLpwDxsU+7DDNwasf2mKrpMSOWEL377gNZTy5waFkCYvS3GVaLIz6bvikH4rAwHrCOxHw0t/5iCoImYCA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.1",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.1",
-          "Microsoft.Extensions.Primitives": "10.0.1"
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.3",
+          "Microsoft.Extensions.Primitives": "10.0.3"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -319,26 +319,26 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "+b3DligYSZuoWltU5YdbMpIEUHNZPgPrzWfNiIuDkMdqOl93UxYB5KzS3lgpRfTXJhTNpo/CZ8w/sTkDTPDdxQ==",
+        "resolved": "10.0.3",
+        "contentHash": "4TD9AXDRsipTmaemwnjt/DM5Ri0de2JzHQhvZ4woBTjUtL4XrPNsMrOk5oiLJAx1gTrE6pOIhxv+lEde5F6CZA==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.1"
+          "Microsoft.Extensions.Primitives": "10.0.3"
         }
       },
       "Microsoft.Extensions.FileProviders.Physical": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "4bxzGXIzZnz0Bf7czQ72jGvpOqJsRW/44PS7YLFXTTnu6cNcPvmSREDvBoH0ZVP2hAbMfL4sUoCUn54k70jPWw==",
+        "resolved": "10.0.3",
+        "contentHash": "8qLl5LXtcj6Z8yPbHAA/a57fvvl9nUCdi59AJFuixcWM4wSuENZ8jjoRATOKs/I4vOi/bDe0d5LqGSSLE634eA==",
         "dependencies": {
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
-          "Microsoft.Extensions.FileSystemGlobbing": "10.0.1",
-          "Microsoft.Extensions.Primitives": "10.0.1"
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.3",
+          "Microsoft.Extensions.Primitives": "10.0.3"
         }
       },
       "Microsoft.Extensions.FileSystemGlobbing": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "49dFvGJjLSwGn76eHnP1gBvCJkL8HRYpCrG0DCvsP6wRpEQRLN2Fq8rTxbP+6jS7jmYKCnSVO5C65v4mT3rzeA=="
+        "resolved": "10.0.3",
+        "contentHash": "oM7pl8uJz8WRPRlh4AGQS61aeV9GOfTu89yqTiRSYyyMuCNVkbNra9zEk7ApyJ/sZrUpbjOZCRHuitCEsTWghg=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
@@ -398,8 +398,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "DO8XrJkp5x4PddDuc/CH37yDBCs9BYN6ijlKyR3vMb55BP1Vwh90vOX8bNfnKxr5B2qEI3D8bvbY1fFbDveDHQ=="
+        "resolved": "10.0.3",
+        "contentHash": "GEcpTwo7sUoLGGNTqV1FZEuL+tTD9m81NX/mh099dqGNna07/UGZShKQNZRw4hv6nlliSUwYQgSYc7OR99Jufg=="
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
@@ -471,8 +471,8 @@
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+        "resolved": "10.0.103",
+        "contentHash": "cMtGW5/r0ck72Jg2QwZcNTX59z+iB/B1kW84VMa/eX8L19DhHIuIcQjfK0pgLLBxd60Jl0Bj9GUolcM0MnJnZA=="
       },
       "Microsoft.VisualBasic": {
         "type": "Transitive",
@@ -516,41 +516,41 @@
       },
       "NuGet.Common": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "AegMASeOhhm2flGk53b/YtINs2H+zKMnV5fTs3rRo08JMQ3gqrbJUSjiEMOKt5d541IhVA+pHDWVsDCZ+5g7Fg==",
+        "resolved": "7.3.0",
+        "contentHash": "y+7cQuzc6zePfo3GdueKgFAfE06pyNv1EGeordAMXotm6WEJw/m7UHv7GSLnib2HEPpzUk4Wvxgn9VgWkIe6Yw==",
         "dependencies": {
-          "NuGet.Frameworks": "7.0.1"
+          "NuGet.Frameworks": "7.3.0"
         }
       },
       "NuGet.Configuration": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "En8aIvZywOmgi+Q2Tv7VUELSYc3OCTwmzItr2N3j5pVIBQE92HbOa1b4+fJJbl9X/rAOkNon3fxjwYeqrdMRrw==",
+        "resolved": "7.3.0",
+        "contentHash": "9qNpnZP73pfGm1MYET78OCW/HNnKNZpTfWPB2z/EyxQnfWtJBANeFyogX8s7S+oWMbR+EG2w6jbDVKdvVJfCXA==",
         "dependencies": {
-          "NuGet.Common": "7.0.1",
-          "System.Security.Cryptography.ProtectedData": "9.0.6"
+          "NuGet.Common": "7.3.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
         }
       },
       "NuGet.Frameworks": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "dUDwg8VYTyT+ZbLdC7hUUHFF530HeRl4jcxclKJY0o96f3nv0eZvojXwjRkq2HKzuyRCcVD4T24aEF83CUmBzA=="
+        "resolved": "7.3.0",
+        "contentHash": "AnhSFUOrCrWp7pGtqhfOxa5HKm4rfpQxuatGDKzpGtTczasj6OcGVtB74PyqW7osdu9/BtkjnkAYvNk5iT82Gg=="
       },
       "NuGet.Packaging": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "hpC6Fx5VlMa42cSZDQ10TKDFHLoMpa8NbDwYSnCiGd4IPiG9+5ywWuxHjVbYYA7/PmJry5hs1GyJjvHV8bQmLw==",
+        "resolved": "7.3.0",
+        "contentHash": "yvmJ8LUPUVMm2DAKSK3+QfJKoCxQR1NuyPYLHqFHb1zmUcGwq+IvSl/4JjUivJDztXnI9GSVlE/SjQLsRJPoYw==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.3",
-          "NuGet.Configuration": "7.0.1",
-          "NuGet.Versioning": "7.0.1",
-          "System.Security.Cryptography.Pkcs": "9.0.6"
+          "NuGet.Configuration": "7.3.0",
+          "NuGet.Versioning": "7.3.0",
+          "System.Security.Cryptography.Pkcs": "8.0.1"
         }
       },
       "NuGet.Versioning": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "tu68LnZqiLM/VyLQzPRqedopMi/M+5/6JqwB2Xkd0AWXRpUWewkVv77asVB7wgjMPVzQFK2sBy7AuxV49UzuvQ=="
+        "resolved": "7.3.0",
+        "contentHash": "iOQPAdnVgj2U+K3AcdGGGcdS1tWyh3nvr64eqTDFCsDuHySBXSHRhl7eR8hdc0BZHxDjacRstbuaJKCurt2oPw=="
       },
       "Parlot": {
         "type": "Transitive",
@@ -572,8 +572,8 @@
       },
       "System.CodeDom": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "owy+NlWSBRNLZO8CZ7IguuaPHHiAivjstTciM7YlXyDDqBY26FMl3F9Nw04n8Dog1JaxFlZiEIEXKPaigRmkNg=="
+        "resolved": "10.0.3",
+        "contentHash": "+G1mBhHJp8taiDcHK1gmckOZ884n9JeIrS1dzFYZhSa8oTiIF+EagIyAyCOQzdBbbES7eb9AkjGBlUZqqoCaeg=="
       },
       "System.Collections": {
         "type": "Transitive",
@@ -604,8 +604,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "kdTe61B8P7i2M1pODC3MLbZ/CfFGjpC6c6jzxjQoB5DHZNewayCRqgFUmx3JKB6vLQtozpMQEiw+R5fO32Jv4g=="
+        "resolved": "10.0.3",
+        "contentHash": "gpKPycgDFS2oAPr0yaqwBmShE1ya4yMMkn3lxBPcXrsCI4KL10xSu0cSUzeajQ7LKjb3EsUAgjhBiPGrGU6vSQ=="
       },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
@@ -716,8 +716,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "26LbFXHKd7PmRnWlkjnYgmjd5B6HYVG+1MpTO25BdxTJnx6D0O16JPAC/S4YBqjtt4YpfGj1QO/Ss6SPMGEGQw=="
+        "resolved": "10.0.3",
+        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
       },
       "System.Linq": {
         "type": "Transitive",
@@ -862,19 +862,19 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "zpcfT/wacPPhE17zcudozlxQtWN/84qyiMyZNGLnK4cj2IMBtLsZYwYjVnALUhPliwyUVj/P7kaZvBWYBCnf2Q==",
+        "resolved": "10.0.3",
+        "contentHash": "xtgymSlbWSeg/7JEwDbyX0YWJlyBhKqZwRk0edFZ0axqZYWtGgcP09rwfzQgqYiFnpQekZ/ur9Dr9YFCKkJK0A==",
         "dependencies": {
-          "System.Collections.Immutable": "10.0.1"
+          "System.Collections.Immutable": "10.0.3"
         }
       },
       "System.Reflection.MetadataLoadContext": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "oR2JAGKrPXc6TjR5u7A1iovxg0U80l1xmxztI8BdqHuJtyFnsg+ddOFu3B4Cx5c39XyVZpq4109A+eCkgp4q/Q==",
+        "resolved": "10.0.3",
+        "contentHash": "rlWB/1Phq2mKv3Sbr33K41pyNpP7L7OGL8zEFrGoj32gLopbPmbCOxfcV2NCh5cCVXFVtdI4w3XK0W2b2jcrOA==",
         "dependencies": {
-          "System.Collections.Immutable": "10.0.1",
-          "System.Reflection.Metadata": "10.0.1"
+          "System.Collections.Immutable": "10.0.3",
+          "System.Reflection.Metadata": "10.0.3"
         }
       },
       "System.Reflection.Primitives": {
@@ -997,8 +997,8 @@
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
-        "resolved": "9.0.6",
-        "contentHash": "yErfw/3pZkJE/VKza/Cm5idTpIKOy/vsmVi59Ta5SruPVtubzxb8CtnE8tyUpzs5pr0Y28GUFfSVzAhCLN3F/Q=="
+        "resolved": "8.0.0",
+        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
       },
       "System.Security.Cryptography.Xml": {
         "type": "Transitive",
@@ -1072,16 +1072,16 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "cVAka0o1rJJ5/De0pjNs7jcaZk5hUGf1HGzUyVmE2MEB1Vf0h/8qsWxImk1zjitCbeD2Avaq2P2+usdvqgbeVQ=="
+        "resolved": "10.0.3",
+        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "EsgwDgU1PFqhrFA9l5n+RBu76wFhNGCEwu8ITrBNhjPP3MxLyklroU5GIF8o6JYpYg6T4KD/VICfMdgPAvNp5g==",
+        "resolved": "10.0.3",
+        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
         "dependencies": {
-          "System.IO.Pipelines": "10.0.1",
-          "System.Text.Encodings.Web": "10.0.1"
+          "System.IO.Pipelines": "10.0.3",
+          "System.Text.Encodings.Web": "10.0.3"
         }
       },
       "System.Text.RegularExpressions": {
@@ -1234,7 +1234,7 @@
         "type": "Project",
         "dependencies": {
           "CsvHelper": "[33.1.0, )",
-          "dgt.power.common": "[2.1.0-beta.20, )"
+          "dgt.power.common": "[2.1.0-beta.33, )"
         }
       },
       "dgt.power.codegeneration": {
@@ -1244,8 +1244,8 @@
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.2.10, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.2.10, )",
           "Spectre.Console.Cli": "[0.53.1, )",
-          "System.CodeDom": "[10.0.1, )",
-          "dgt.power.common": "[2.1.0-beta.20, )"
+          "System.CodeDom": "[10.0.3, )",
+          "dgt.power.common": "[2.1.0-beta.33, )"
         }
       },
       "dgt.power.common": {
@@ -1260,35 +1260,35 @@
       "dgt.power.export": {
         "type": "Project",
         "dependencies": {
-          "dgt.power.common": "[2.1.0-beta.20, )"
+          "dgt.power.common": "[2.1.0-beta.33, )"
         }
       },
       "dgt.power.import": {
         "type": "Project",
         "dependencies": {
           "DocumentFormat.OpenXml": "[3.4.1, )",
-          "dgt.power.common": "[2.1.0-beta.20, )"
+          "dgt.power.common": "[2.1.0-beta.33, )"
         }
       },
       "dgt.power.maintenance": {
         "type": "Project",
         "dependencies": {
-          "dgt.power.common": "[2.1.0-beta.20, )"
+          "dgt.power.common": "[2.1.0-beta.33, )"
         }
       },
       "dgt.power.profile": {
         "type": "Project",
         "dependencies": {
-          "dgt.power.common": "[2.1.0-beta.20, )"
+          "dgt.power.common": "[2.1.0-beta.33, )"
         }
       },
       "dgt.power.push": {
         "type": "Project",
         "dependencies": {
-          "NuGet.Packaging": "[7.0.1, )",
-          "System.Reflection.MetadataLoadContext": "[10.0.1, )",
+          "NuGet.Packaging": "[7.3.0, )",
+          "System.Reflection.MetadataLoadContext": "[10.0.3, )",
           "UiPath.Workflow": "[6.0.3, )",
-          "dgt.power.common": "[2.1.0-beta.20, )",
+          "dgt.power.common": "[2.1.0-beta.33, )",
           "dgt.registration": "[1.0.1, )"
         }
       }

--- a/src/modules/dgt.power.analyzer/dgt.power.analyzer.csproj
+++ b/src/modules/dgt.power.analyzer/dgt.power.analyzer.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.1.0" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/modules/dgt.power.codegeneration/Constants/FileNames.cs
+++ b/src/modules/dgt.power.codegeneration/Constants/FileNames.cs
@@ -15,30 +15,37 @@ public static class FileNames
 
     public static class Typescript
     {
-        public static string CustomApi => "customapi";
-        public static string Entity => "entity";
-        public static string EntityRef => "entityref";
-        public static string Form => "form";
-        public static string Model => "model";
-        public static string Odata => "odata";
-        public static string OptionSetValues => "optionsetvalues";
-        public static string SdkMessageNames => "sdkmessagenames";
-        public static string Services => "services";
-        public static string Utils => "utils";
-        public static string Webapi => "webapi";
+        public static class FileNamePart
+        {
+            public static string CustomApi => "customapi";
+            public static string Entity => "entity";
+            public static string EntityRef => "entityref";
+            public static string Form => "form";
+            public static string Model => "model";
+            public static string Odata => "odata";
+            public static string Services => "services";
+            public static string TestHelper => "mock.form";
+            public static string Utils => "utils";
+            public static string Webapi => "webapi";
+        }
 
-        public static string TestHelper => "mock.form";
+        public static class FileExtension
+        {
+            public static string TsExtension => "ts";
+            public static string TypeExtension => "d.ts";
+        }
 
-        public static string TsTypeExtension => "d.ts";
+        public static class FileNames
+        {
+            public static string OptionSetValues => "optionsetvalues";
+            public static string SdkMessageNames => "sdkmessagenames";
+            public static string TsAuxiliaryExtTypes => "xrm_types_ext";
+            public static string XrmMockFormContextBuilder => "xrm_mock_form_test_context_builder";
+            public static string XrmMockFormContextTypes => "xrm_mock_form_test_context_types";
+            public static string XrmMockFormODataFilter => "xrm_mock_form_odata_filter";
+            public static string XrmMockTestTypingsFileName => "xrm_form_tester";
+            public static string XrmWebApiTypingsFileName => "xrm_webapi_ext";
 
-        public static string TsExtension => "ts";
-
-        public static string XrmWebApiTypingsFileName => "xrm_webapi_ext";
-        public static string XrmMockTypingsFileName => "xrm_mock_form";
-
-        public static string XrmMockFormContextBuilder => "xrm_mock_form_test_context_builder";
-
-        public static string XrmMockFormContextTypes => "xrm_mock_form_test_context_types";
-
+        }
     }
 }

--- a/src/modules/dgt.power.codegeneration/Constants/Folders.cs
+++ b/src/modules/dgt.power.codegeneration/Constants/Folders.cs
@@ -9,6 +9,7 @@ public static class Folders
     public const string Model = "Model";
 #pragma warning restore S2339
     public static string Typescript => "TypeScript";
+    public static string TypescriptEntities => "Entities";
     public static string TypescriptEntity => "Entity";
     public static string TypescriptEntityForms => "Forms";
     public static string TypescriptEntityTestHelper => "TestHelper";

--- a/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorker.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorker.cs
@@ -2,6 +2,7 @@
 // DIGITALL Nature licenses this file to you under the Microsoft Public License.
 
 using System.Diagnostics;
+using System.IO;
 using System.Reflection;
 using dgt.power.codegeneration.Base;
 using dgt.power.codegeneration.Constants;
@@ -52,6 +53,8 @@ public abstract class TypescriptGeneratorWorker
         Debug.Assert(templateFileName != null, $"{nameof(templateFileName)} {NOT_NULL}");
         Debug.Assert(args != null, $"{nameof(args)} {NOT_NULL}");
         Debug.Assert(extension != null, $"{nameof(extension)} {NOT_NULL}");
+
+        AnsiConsole.MarkupLine($"Reading File: [bold green] {templateFileName}.{extension} [/]");
 
         var reader = new StreamReader(Assembly.GetCallingAssembly()
             .GetManifestResourceStream($"dgt.power.codegeneration.Templates.tsl.{templateFileName}.{extension}")!);

--- a/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerFull.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerFull.cs
@@ -6,6 +6,7 @@ using dgt.power.codegeneration.Base;
 using dgt.power.codegeneration.Constants;
 using dgt.power.codegeneration.Generators.Contracts;
 using dgt.power.codegeneration.Logic;
+using dgt.power.codegeneration.Model;
 using dgt.power.codegeneration.Services.Contracts;
 using dgt.power.codegeneration.Templates;
 using dgt.power.codegeneration.Templates.ts;
@@ -27,11 +28,11 @@ public class TypescriptGeneratorWorkerFull(IMetadataService metadataService)
         Debug.Assert(config != null, nameof(config) + " != null");
 
 
-        CreateTemplateFile(new D365ModelTemplate(config.TypingPath), FileNames.Typescript.Model, args);
-        CreateTemplateFile(new D365ServicesTemplate(config.TypingPath), FileNames.Typescript.Services, args);
-        CreateTemplateFile(new D365WebApiTemplate(config.TypingPath), FileNames.Typescript.Webapi, args);
-        CreateTemplateFile(new D365UtilsTemplate(config.TypingPath), FileNames.Typescript.Utils, args);
-        CreateTemplateFile(new D365ODataTemplate(config.TypingPath), FileNames.Typescript.Odata, args);
+        CreateTemplateFile(new D365ModelTemplate(config.TypingPath), FileNames.Typescript.FileNamePart.Model, args);
+        CreateTemplateFile(new D365ServicesTemplate(config.TypingPath), FileNames.Typescript.FileNamePart.Services, args);
+        CreateTemplateFile(new D365WebApiTemplate(config.TypingPath), FileNames.Typescript.FileNamePart.Webapi, args);
+        CreateTemplateFile(new D365UtilsTemplate(config.TypingPath), FileNames.Typescript.FileNamePart.Utils, args);
+        CreateTemplateFile(new D365ODataTemplate(config.TypingPath), FileNames.Typescript.FileNamePart.Odata, args);
     }
 
     /// <summary>
@@ -92,7 +93,7 @@ public class TypescriptGeneratorWorkerFull(IMetadataService metadataService)
                 new D365EntityTemplate(config.TypingPath, metadata, config,
                 metadataService.RetrieveOrganizationLanguage());
             // Create the template file
-            CreateTemplateFile(template, $"{metadata.LogicalName.ToLowerInvariant()}.{FileNames.Typescript.Entity}", args);
+            CreateTemplateFile(template, $"{metadata.LogicalName.ToLowerInvariant()}.{FileNames.Typescript.FileNamePart.Entity}", args);
         }
     }
 
@@ -107,7 +108,7 @@ public class TypescriptGeneratorWorkerFull(IMetadataService metadataService)
                 metadataService.RetrieveEntityMetadata(entity, EntityFilters.Attributes | EntityFilters.Entity);
 
             var fileName = Path.Combine(args.TargetDirectory, args.Folder, Folders.Typescript,
-                $"{metadata.LogicalName.ToLowerInvariant()}.{FileNames.Typescript.EntityRef}.ts");
+                $"{metadata.LogicalName.ToLowerInvariant()}.{FileNames.Typescript.FileNamePart.EntityRef}.ts");
 
             using var file = File.CreateText(fileName);
             AnsiConsole.MarkupLine($"Creating File: [bold green] {fileName} [/]");
@@ -127,51 +128,7 @@ public class TypescriptGeneratorWorkerFull(IMetadataService metadataService)
 
         foreach (var entity in config.Entities)
         {
-            var metadata =
-                metadataService.RetrieveEntityMetadata(entity, EntityFilters.Attributes | EntityFilters.Entity);
-
-            var forms = config.OnlyFormsFromSolutions
-                ? metadataService.RetrieveFormsDetailsFromSolutions(metadata.LogicalName, config.Solutions, null)
-                : metadataService.RetrieveFormsDetails(metadata.LogicalName, null);
-
-            foreach (var formDetail in forms)
-            {
-                var form =
-                    $"{metadata.LogicalName}.{Formatter.Sanitize(formDetail.Key.ToLowerInvariant(), true).Replace(' ', '_')}.{FileNames.Typescript.Form}";
-                if (config.Forms.Length != 0)
-                {
-                    config.Forms.Where(e => e.EndsWith(".ts", StringComparison.InvariantCulture))
-                        .ToList()
-                        .ForEach(e =>
-                            AnsiConsole.MarkupLine(Warnings.TsExtensionDeprecation));
-                    config.Forms = config.Forms.Select(e =>
-                            e.EndsWith(".ts", StringComparison.InvariantCulture)
-                                ? e.Remove(e.LastIndexOf(".ts", StringComparison.Ordinal))
-                                : e)
-                        .ToArray();
-                }
-
-                if (config.Forms.Length != 0 && !config.Forms.Contains(form))
-                {
-                    AnsiConsole.MarkupLine($"Skip: {form}");
-                    continue;
-                }
-
-                var formname = formDetail.Key
-                    .Replace(".main", "Main").Replace(".quickview", "QuickView")
-                    .Replace(".quickcreate", "QuickCreate");
-
-
-                var fileName = Path.Combine(args.TargetDirectory, args.Folder, Folders.Typescript, $"{form}.ts");
-                using var file = File.CreateText(fileName);
-                AnsiConsole.MarkupLine($"Creating File: [bold green] {fileName} [/]");
-                //TODO: not smart, but works
-                var content = new D365EntityFormTemplate(config.TypingPath, form,
-                    formname, formDetail.Value, metadata, config,
-                    metadataService.RetrieveOrganizationLanguage()).TransformText();
-
-                file.Write(content);
-            }
+            GenerateEntityFormForEntity(args, config, entity);
         }
     }
 
@@ -202,7 +159,7 @@ public class TypescriptGeneratorWorkerFull(IMetadataService metadataService)
         template = new D365SdkMessagesTemplate(sdkMessages, config);
 
         // Create the template file
-        CreateTemplateFile(template, $"{FileNames.Typescript.SdkMessageNames}", args);
+        CreateTemplateFile(template, $"{FileNames.Typescript.FileNames.SdkMessageNames}", args);
     }
 
     /// <summary>
@@ -232,7 +189,7 @@ public class TypescriptGeneratorWorkerFull(IMetadataService metadataService)
         template = new D365OptionSetsTemplate(optionSets, config);
 
         // Create the template file
-        CreateTemplateFile(template, $"{FileNames.Typescript.OptionSetValues}", args);
+        CreateTemplateFile(template, $"{FileNames.Typescript.FileNames.OptionSetValues}", args);
     }
 
     public void GenerateBusinessProcessFlowsFull(CodeGenerationVerb args, CodeGenerationConfig config)
@@ -261,6 +218,73 @@ public class TypescriptGeneratorWorkerFull(IMetadataService metadataService)
     }
 
     #endregion
+
+    /// <summary>
+    /// Inner logic of generate entity forms
+    /// </summary>
+    /// <param name="args"></param>
+    /// <param name="config"></param>
+    /// <param name="entityLogicalName"></param>
+    private void GenerateEntityFormForEntity(CodeGenerationVerb args, CodeGenerationConfig config, string entityLogicalName)
+    {
+        var entityMetadata =
+                metadataService.RetrieveEntityMetadata(entityLogicalName, EntityFilters.Attributes | EntityFilters.Entity);
+
+        var forms = config.OnlyFormsFromSolutions
+            ? metadataService.RetrieveFormsDetailsFromSolutions(entityMetadata.LogicalName, config.Solutions, null)
+            : metadataService.RetrieveFormsDetails(entityMetadata.LogicalName, null);
+
+        foreach (var formDetail in forms)
+        {
+            GenerateFormDetailFile(args, config, entityMetadata, formDetail);
+        }
+    }
+
+    /// <summary>
+    /// Internal loop logic for generating the form detail file
+    /// </summary>
+    /// <param name="args"></param>
+    /// <param name="config"></param>
+    /// <param name="entityMetadata"></param>
+    /// <param name="formDetail"></param>
+    private void GenerateFormDetailFile(CodeGenerationVerb args, CodeGenerationConfig config, EntityMetadata entityMetadata, KeyValuePair<string, FormDetail> formDetail)
+    {
+        var form =
+               $"{entityMetadata.LogicalName}.{Formatter.Sanitize(formDetail.Key.ToLowerInvariant(), true).Replace(' ', '_')}.{FileNames.Typescript.FileNamePart.Form}";
+        if (config.Forms.Length != 0)
+        {
+            config.Forms.Where(e => e.EndsWith(".ts", StringComparison.InvariantCulture))
+                .ToList()
+                .ForEach(e =>
+                    AnsiConsole.MarkupLine(Warnings.TsExtensionDeprecation));
+            config.Forms = config.Forms.Select(e =>
+                    e.EndsWith(".ts", StringComparison.InvariantCulture)
+                        ? e.Remove(e.LastIndexOf(".ts", StringComparison.Ordinal))
+                        : e)
+                .ToArray();
+        }
+
+        if (config.Forms.Length != 0 && !config.Forms.Contains(form))
+        {
+            AnsiConsole.MarkupLine($"Skip: {form}");
+            return;
+        }
+
+        var formname = formDetail.Key
+            .Replace(".main", "Main").Replace(".quickview", "QuickView")
+            .Replace(".quickcreate", "QuickCreate");
+
+
+        var fileName = Path.Combine(args.TargetDirectory, args.Folder, Folders.Typescript, $"{form}.ts");
+        using var file = File.CreateText(fileName);
+        AnsiConsole.MarkupLine($"Creating File: [bold green] {fileName} [/]");
+        //TODO: not smart, but works
+        var content = new D365EntityFormTemplate(config.TypingPath, form,
+            formname, formDetail.Value, entityMetadata, config,
+            metadataService.RetrieveOrganizationLanguage()).TransformText();
+
+        file.Write(content);
+    }
 
     #region NotImplemented
     public void GenerateCustomApis(CodeGenerationVerb arg, CodeGenerationConfig config) => throw new NotImplementedException();

--- a/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerLight.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Worker/TypescriptGeneratorWorkerLight.cs
@@ -2,12 +2,14 @@
 // DIGITALL Nature licenses this file to you under the Microsoft Public License.
 
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using dgt.power.codegeneration.Base;
 using dgt.power.codegeneration.Constants;
 using dgt.power.codegeneration.Generators.Contracts;
 using dgt.power.codegeneration.Logic;
 using dgt.power.codegeneration.Model;
+using dgt.power.codegeneration.Services;
 using dgt.power.codegeneration.Services.Contracts;
 using dgt.power.codegeneration.Templates;
 using dgt.power.codegeneration.Templates.tsl.ViewModels;
@@ -37,6 +39,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         _templateOptions.Filters.AddFilter("xrmMockAttributeType", CustomLiquidFilters.XrmMockAttributetype);
         _templateOptions.Filters.AddFilter("xrmMockControlType", CustomLiquidFilters.GetControlXrmMockFormFromAttribute);
         _templateOptions.Filters.AddFilter("requiredAttributeLevel", CustomLiquidFilters.GetRequiredAttributeLevel);
+        _templateOptions.Filters.AddFilter("getAttributeItem", CustomLiquidFilters.GetAttributeItem);
         _templateOptions.ValueConverters.Add(o => o is AttributeMetadata p ? new AttributeMetadataViewModel(p) : null);
         _templateOptions.ValueConverters.Add(o => o is OptionMetadata l ? new OptionMetadataViewModel(l) : null);
         _templateOptions.ValueConverters.Add(o => o is BpfControlDetail r ? new BpfControlViewModel(r): null);
@@ -50,6 +53,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         _templateOptions.MemberAccessStrategy.Register<Option>();
         _templateOptions.MemberAccessStrategy.Register<SdkMessageViewModel>();
         _templateOptions.MemberAccessStrategy.Register<FormDetail>();
+        _templateOptions.MemberAccessStrategy.Register<QuickViewFormControl>();
         _templateOptions.MemberAccessStrategy.Register<FormAttributeData>();
         _templateOptions.MemberAccessStrategy.Register<FormControlViewModel>();
         _templateOptions.MemberAccessStrategy.Register<BpfControlViewModel>();
@@ -63,7 +67,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
     {
         var reader = new StreamReader(Assembly.GetCallingAssembly()
             .GetManifestResourceStream($"dgt.power.codegeneration.Templates.tsl.{templateName}")!);
-        var parser = new FluidParser();
+        var parser = new FluidParser(new FluidParserOptions { AllowParentheses = true });
         var liquidTemplate = parser.Parse(reader.ReadToEnd());
         return liquidTemplate;
     }
@@ -90,6 +94,8 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
             AnsiConsole.MarkupLine($"Using Base Language: {languageCode}");
         }
 
+        CopyTemplateFileContent(args, FileNames.Typescript.FileNames.TsAuxiliaryExtTypes, FileNames.Typescript.FileExtension.TypeExtension);
+
         // Iterate through each entity in the configuration
         foreach (var entity in config.Entities.OrderBy(entityName => entityName))
         {           
@@ -106,11 +112,10 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
             var context = new TemplateContext(viewModel, _templateOptions);
             var content = liquidTemplate.Render(context);
             var formEntityName = metadata.LogicalName.ToLowerInvariant().Trim();
-
             CreateFile(content,
-                $"{formEntityName}.{FileNames.Typescript.Entity}",
+                $"{formEntityName}.{FileNames.Typescript.FileNamePart.Entity}",
                 args,
-                FileNames.Typescript.TsTypeExtension,
+                FileNames.Typescript.FileExtension.TypeExtension,
                 GetEntityFolderName(metadata.LogicalName, Folders.TypescriptEntity));
         }
     }
@@ -123,47 +128,88 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         var liquidTemplateForm = InitializeLiquidTemplate("EntityForm.liquid");
         var liquidTemplateFormTestHelpers = InitializeLiquidTemplate("EntityFormTestHelper.liquid");
 
-        Dictionary<string, SortedSet<BpfControlDetail>> bpfControls = GetCompleteEntityBpfControlList(config);
-
-        foreach (var entity in config.Entities.OrderBy(entityName => entityName))
+        var bpfControls = GetCompleteEntityBpfControlList(config);
+        var  entityWithParsedFormList = GenerateEntityWithMetadata(config, bpfControls);
+        var flatListParseForm = GetFlatFormDetail(entityWithParsedFormList);
+        foreach (var entityParsedForm in entityWithParsedFormList)
         {
-            var metadata = _metadataService.RetrieveEntityMetadata(entity, EntityFilters.Attributes | EntityFilters.Entity);
-            // do not create forms for bpf entities
-            if (metadata.IsBPFEntity == true)
+            var entityMetada = entityParsedForm.EntityMetadata;
+            var bpfControlsForEntity = bpfControls.GetValueOrDefault(entityMetada.LogicalName) ?? [];
+
+            foreach (var parsedForm in entityParsedForm.ParsedFormDetail)
             {
-                AnsiConsole.MarkupLine($"Skip form generation for BPF Entity {metadata.LogicalName}");
-                continue;
-            }
-
-            var bpfControlsForEntity = bpfControls.GetValueOrDefault(entity) ?? [];
-
-            var forms = config.OnlyFormsFromSolutions
-                ? _metadataService.RetrieveFormsDetailsFromSolutions(metadata.LogicalName, config.Solutions, bpfControlsForEntity)
-                : _metadataService.RetrieveFormsDetails(metadata.LogicalName, bpfControlsForEntity);
-
-            foreach (var formDetail in forms)
-            {
-                var formName =  $"{metadata.LogicalName.Trim()}.{Formatter.Sanitize(formDetail.Key.ToLowerInvariant().Trim(), true).Replace(' ', '_')}.{FileNames.Typescript.Form}";
+                var formName =  $"{entityMetada.LogicalName.Trim()}.{Formatter.Sanitize(parsedForm.Key.ToLowerInvariant().Trim(), true).Replace(' ', '_')}.{FileNames.Typescript.FileNamePart.Form}";
                 if (ShouldSkipFormForConfig(config.Forms, formName))
                 {
                     AnsiConsole.MarkupLine($"Skip: {formName}");
                     continue;
                 }
-
-                CreateFormFile(formDetail, metadata, liquidTemplateForm, args, formName, bpfControlsForEntity);
+                FormParser.MapQuickFormId(parsedForm.Value, flatListParseForm);
+                CreateFormFile(parsedForm, entityMetada, liquidTemplateForm, args, formName, bpfControlsForEntity);
                 if (config.XrmMockFormHelpers)
                 {
-                    CreateFormTestHelperFile(formDetail, metadata, liquidTemplateFormTestHelpers, args, $"{formName}.{FileNames.Typescript.TestHelper}", bpfControlsForEntity);
+                    CreateFormTestHelperFile(parsedForm, entityMetada, liquidTemplateFormTestHelpers, args, $"{formName}.{FileNames.Typescript.FileNamePart.TestHelper}", bpfControlsForEntity);
                 }
             }
         }
 
         if (config.XrmMockFormHelpers)
         {
-            CopyTemplateFileContent(args, FileNames.Typescript.XrmMockFormContextBuilder, FileNames.Typescript.TsExtension);
-            CopyTemplateFileContent(args, FileNames.Typescript.XrmMockFormContextTypes, FileNames.Typescript.TsExtension);
-            CopyTemplateFileContent(args, FileNames.Typescript.XrmMockTypingsFileName, FileNames.Typescript.TsTypeExtension);
+            CopyTemplateFileContent(args, FileNames.Typescript.FileNames.XrmMockFormODataFilter, FileNames.Typescript.FileExtension.TsExtension);
+            CopyTemplateFileContent(args, FileNames.Typescript.FileNames.XrmMockFormContextBuilder, FileNames.Typescript.FileExtension.TsExtension);
+            CopyTemplateFileContent(args, FileNames.Typescript.FileNames.XrmMockFormContextTypes, FileNames.Typescript.FileExtension.TsExtension);
+            CopyTemplateFileContent(args, FileNames.Typescript.FileNames.XrmMockTestTypingsFileName, FileNames.Typescript.FileExtension.TypeExtension);
         }
+    }
+
+    /// <summary>
+    /// Generate intermediate structure as postprocessing of the overall list is needed to link forms
+    /// </summary>
+    /// <param name="args"></param>
+    /// <param name="config"></param>
+    /// <param name="bpfControls"></param>
+    /// <returns></returns>
+    private List<EntityWithMetadataFormData> GenerateEntityWithMetadata(CodeGenerationConfig config, Dictionary<string, SortedSet<BpfControlDetail>> bpfControls)
+    {
+        List<EntityWithMetadataFormData> entityWithMetadataForms = new List<EntityWithMetadataFormData>();
+
+        foreach (var entity in config.Entities.OrderBy(entityName => entityName))
+        {
+            var entityMetadata = _metadataService.RetrieveEntityMetadata(entity, EntityFilters.Attributes | EntityFilters.Entity);
+            if (entityMetadata == null)
+            {
+                continue;
+            }
+            // do not create forms for bpf entities
+            if (entityMetadata.IsBPFEntity == true)
+            {
+                AnsiConsole.MarkupLine($"Skip form generation for BPF Entity {entityMetadata.LogicalName}");
+                continue;
+            }
+
+            var bpfControlsForEntity = bpfControls.GetValueOrDefault(entity) ?? [];
+
+            var forms = config.OnlyFormsFromSolutions
+                ? _metadataService.RetrieveFormsDetailsFromSolutions(entityMetadata.LogicalName, config.Solutions, bpfControlsForEntity)
+                : _metadataService.RetrieveFormsDetails(entityMetadata.LogicalName, bpfControlsForEntity);
+
+            entityWithMetadataForms.Add(new EntityWithMetadataFormData()
+            {
+                EntityMetadata = entityMetadata,
+                ParsedFormDetail = forms,
+            });
+        }
+        return entityWithMetadataForms;
+    }
+
+    /// <summary>
+    /// Get flat form detail
+    /// </summary>
+    /// <param name="entityWithMetadataFormDatas"></param>
+    /// <returns></returns>
+    private static List<FormDetail> GetFlatFormDetail(List<EntityWithMetadataFormData> entityWithMetadataFormDatas)
+    {
+        return entityWithMetadataFormDatas.Select(x => x.ParsedFormDetail.Values.ToList()).SelectMany(x => x).ToList();
     }
 
     /// <summary>
@@ -196,7 +242,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         var context = new TemplateContext(viewModel, _templateOptions);
         var content = liquidTemplate.Render(context);
 
-        CreateFile(content, FileNames.Typescript.SdkMessageNames, args, FileNames.Typescript.TsTypeExtension);
+        CreateFile(content, FileNames.Typescript.FileNames.SdkMessageNames, args, FileNames.Typescript.FileExtension.TypeExtension);
     }
 
     /// <summary>
@@ -217,7 +263,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         }
 
        var customApis = _metadataService.RetrieveCustomAPIs(config);
-       CopyTemplateFileContent(args, FileNames.Typescript.XrmWebApiTypingsFileName, FileNames.Typescript.TsTypeExtension);
+       CopyTemplateFileContent(args, FileNames.Typescript.FileNames.XrmWebApiTypingsFileName, FileNames.Typescript.FileExtension.TypeExtension);
        var liquidTemplate = InitializeLiquidTemplate("CustomApi.liquid");
 
         foreach (var customApi in customApis)
@@ -231,8 +277,8 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
             var context = new TemplateContext(viewModel, _templateOptions);
             var content = liquidTemplate.Render(context);
 
-            var customApiName = $"{Formatter.Sanitize(customApi.LogicalName.ToLowerInvariant().Trim(), true).Replace(' ', '_')}.{FileNames.Typescript.CustomApi}";
-            CreateFile(content, customApiName, args, FileNames.Typescript.TsTypeExtension, [Folders.TypescriptCustomApis]);
+            var customApiName = $"{Formatter.Sanitize(customApi.LogicalName.ToLowerInvariant().Trim(), true).Replace(' ', '_')}.{FileNames.Typescript.FileNamePart.CustomApi}";
+            CreateFile(content, customApiName, args, FileNames.Typescript.FileExtension.TypeExtension, [Folders.TypescriptCustomApis]);
         }
     }
 
@@ -266,7 +312,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         var context = new TemplateContext(viewModel, _templateOptions);
         var content = liquidTemplate.Render(context);
 
-        CreateFile(content, FileNames.Typescript.OptionSetValues, args, FileNames.Typescript.TsTypeExtension);
+        CreateFile(content, FileNames.Typescript.FileNames.OptionSetValues, args, FileNames.Typescript.FileExtension.TypeExtension);
     }
 
     /// <summary>
@@ -286,7 +332,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         SortedSet<BpfControlDetail> bpfControls)
     {        
         var content = CreateFormFileContent(formDetail, metadata, liquidTemplate, bpfControls);
-        CreateFile(content, form, args, FileNames.Typescript.TsTypeExtension, GetEntityFolderName(metadata.LogicalName, Folders.TypescriptEntityForms));
+        CreateFile(content, form, args, FileNames.Typescript.FileExtension.TypeExtension, GetEntityFolderName(metadata.LogicalName, Folders.TypescriptEntityForms));
     }
 
     /// <summary>
@@ -306,7 +352,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         SortedSet<BpfControlDetail> bpfControls)
     {
         var content = CreateFormFileContent(formDetail, metadata, liquidTemplate, bpfControls);
-        CreateFile(content, form, args, FileNames.Typescript.TsExtension, GetEntityFolderName(metadata.LogicalName, Folders.TypescriptEntityTestHelper));
+        CreateFile(content, form, args, FileNames.Typescript.FileExtension.TsExtension, GetEntityFolderName(metadata.LogicalName, Folders.TypescriptEntityTestHelper));
     }
 
 
@@ -335,7 +381,6 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
         {
             Name = formname,
             FormDetail = formDetail.Value,
-            EntitySchemaName = metadata.SchemaName,
             Attributes = FilterEntityMetadataAttributes(metadata),
             BpfControls = formDetail.Value.FormType == SystemForm.Options.Type.QuickViewForm ? [] : bpfControls.ToList(),
         };
@@ -414,7 +459,7 @@ public class TypescriptGeneratorWorkerLight : TypescriptGeneratorWorker, ITypesc
     private static string[] GetEntityFolderName(string entityLogicalName, string subFolder)
     {
         var formEntityName = entityLogicalName.ToLowerInvariant().Trim();
-        return [Formatter.CamelCase(Formatter.Sanitize(formEntityName)), subFolder];
+        return [Folders.TypescriptEntities, Formatter.CamelCase(Formatter.Sanitize(formEntityName)), subFolder];
     }
 
     #endregion

--- a/src/modules/dgt.power.codegeneration/Model/EntityWithMetadataFormData.cs
+++ b/src/modules/dgt.power.codegeneration/Model/EntityWithMetadataFormData.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) DIGITALL Nature. All rights reserved
+// DIGITALL Nature licenses this file to you under the Microsoft Public License.
+
+using Microsoft.Xrm.Sdk.Metadata;
+
+namespace dgt.power.codegeneration.Model
+{
+    public class EntityWithMetadataFormData
+    {
+        public required EntityMetadata EntityMetadata { get; set; }
+        public required Dictionary<string, FormDetail> ParsedFormDetail {get; set; }
+    }
+}

--- a/src/modules/dgt.power.codegeneration/Model/FormDetail.cs
+++ b/src/modules/dgt.power.codegeneration/Model/FormDetail.cs
@@ -7,18 +7,20 @@ public class FormDetail
 {
     public SortedSet<FormAttributeData> Attributes { get; }
     public SortedSet<FormXmlControlData> FormControls { get; }
-    public string FormId { get; set; }
+    public string? FormId { get; set; }
     public string FormUniqueName { get; set; }
+    public string FormEntityName { get; set; }
     public int FormType { get; set; }
     public string FormTypeName { get; set; }
     public SortedSet<string> Grids { get; }
     public SortedSet<string> HeaderControlFields { get; }
-    public SortedSet<string> QuickViews { get; }
+    public SortedSet<QuickViewFormControl> QuickViews { get; }
     public SortedSet<TabDetail> TabDetails { get; }
     public SortedDictionary<string, List<string>> Tabs { get; }
 
     public FormDetail()
     {
+        FormId = null;
         Attributes = [];
         FormControls = [];
         FormUniqueName = string.Empty;

--- a/src/modules/dgt.power.codegeneration/Model/QuickViewFormControl.cs
+++ b/src/modules/dgt.power.codegeneration/Model/QuickViewFormControl.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) DIGITALL Nature. All rights reserved
+// DIGITALL Nature licenses this file to you under the Microsoft Public License.
+
+namespace dgt.power.codegeneration.Model
+{
+    public class QuickViewFormControl : IComparable<QuickViewFormControl>
+    {
+        public required string ControlName { get; set; }
+        public required string QuickViewFormId { get; set; }
+
+        public required string QuickViewFormClass { get; set; }
+
+        public int CompareTo(QuickViewFormControl? other)
+        {
+            if (other == null)
+            {
+                return -1;
+            }
+            return string.Compare(ControlName, other.ControlName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return ControlName.GetHashCode();
+        }
+
+        public static bool operator ==(QuickViewFormControl? left, QuickViewFormControl? right)
+        {
+            if (left is null)
+            {
+                return right is null;
+            }
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(QuickViewFormControl? left, QuickViewFormControl? right)
+        {
+            return !(left == right);
+        }
+
+        public static bool operator <(QuickViewFormControl? left, QuickViewFormControl? right)
+        {
+            return left is null ? right is not null : left.CompareTo(right) < 0;
+        }
+
+        public static bool operator <=(QuickViewFormControl? left, QuickViewFormControl? right)
+        {
+            return left is null || left.CompareTo(right) <= 0;
+        }
+
+        public static bool operator >(QuickViewFormControl? left, QuickViewFormControl? right)
+        {
+            return left is not null && left.CompareTo(right) > 0;
+        }
+
+        public static bool operator >=(QuickViewFormControl? left, QuickViewFormControl? right)
+        {
+            return left is null ? right is null : left.CompareTo(right) >= 0;
+        }
+    }
+}

--- a/src/modules/dgt.power.codegeneration/Services/FormParser.cs
+++ b/src/modules/dgt.power.codegeneration/Services/FormParser.cs
@@ -2,19 +2,27 @@
 // DIGITALL Nature licenses this file to you under the Microsoft Public License.
 
 using System.Globalization;
+using dgt.power.codegeneration.Logic;
 using System.Text.RegularExpressions;
 using System.Xml;
 using dgt.power.codegeneration.Constants;
 using dgt.power.codegeneration.Model;
 using dgt.power.dataverse;
 using Microsoft.Xrm.Sdk;
-using static dgt.power.dataverse.SdkMessageFilter.Options;
 
 namespace dgt.power.codegeneration.Services
 {
     public static class FormParser
     {
-        public static FormDetail ParseForm(Entity form, string formUniqueName, SortedSet<BpfControlDetail>? bpfControls)
+        /// <summary>
+        /// Parse form values
+        /// </summary>
+        /// <param name="form"></param>
+        /// <param name="formUniqueName"></param>
+        /// <param name="entityLogicalName"></param>
+        /// <param name="bpfControls"></param>
+        /// <returns></returns>
+        public static FormDetail ParseForm(Entity form, string formUniqueName, string entityLogicalName, SortedSet<BpfControlDetail>? bpfControls)
         {
             var formId = form.GetAttributeValue<Guid>(SystemForm.LogicalNames.FormId).ToString();
             var formxml = form.GetAttributeValue<string>(SystemForm.LogicalNames.FormXml);
@@ -27,6 +35,7 @@ namespace dgt.power.codegeneration.Services
                 FormType = formType,
                 FormTypeName = FormatFormType(GetFormType(formType)),
                 FormUniqueName = formUniqueName,
+                FormEntityName = entityLogicalName,
                 FormId = formId,
             };
 
@@ -47,8 +56,22 @@ namespace dgt.power.codegeneration.Services
 
             // Map bp process controls that will be mapped as "header_process_"
             MapBpfControlsAttributesIntoFormDetail(formDetail, formType, bpfControls);
-
             return formDetail;
+
+        }
+
+        /// <summary>
+        /// Map quick form id to generated form class
+        /// </summary>
+        /// <param name="formDetail"></param>
+        /// <param name="allForms"></param>
+        /// <returns></returns>
+        public static void MapQuickFormId(FormDetail formDetail, List<FormDetail> allForms)
+        {
+            foreach(var quickView in formDetail.QuickViews)
+            {
+                quickView.QuickViewFormClass = GetQuickViewFormClass(quickView.QuickViewFormId, allForms) ?? quickView.QuickViewFormClass ?? "Xrm.Controls.QuickFormControl";
+            }
         }
 
         /// <summary>
@@ -248,11 +271,32 @@ namespace dgt.power.codegeneration.Services
             var quickFormParameters = control.SelectNodes(".//parameters/QuickForms");
             if (quickFormParameters != null && quickFormParameters.Count > 0 && quickFormParameters[0]?.InnerText != null)
             {
-                formDetail.QuickViews.Add(controlId);
+                var quickViewFormId = RetrieveQuickViewFormId(quickFormParameters[0]?.InnerText);
+                var quickControl = new QuickViewFormControl
+                {
+                    ControlName = controlId,
+                    QuickViewFormId = quickViewFormId,
+                    QuickViewFormClass = "Xrm.Controls.QuickFormControl",
+                };
+                formDetail.QuickViews.Add(quickControl);
             }
-
         }
 
+        /// <summary>
+        /// Retrieve quick view form id from the inner xml
+        /// </summary>
+        /// <param name="quickViewFormIdNodeText"></param>
+        /// <returns></returns>
+        private static string RetrieveQuickViewFormId(string? quickViewFormIdNodeText)
+        {
+            if(string.IsNullOrWhiteSpace(quickViewFormIdNodeText))
+            {
+                return string.Empty;
+            }
+            var doc = new XmlDocument();
+            doc.LoadXml(quickViewFormIdNodeText);
+            return doc.SelectSingleNode("//QuickFormIds/QuickFormId")?.InnerText?.ToLowerInvariant() ?? string.Empty;
+        }
         /// <summary>
         /// Map form xml header controls into the attributes and header controls
         /// </summary>
@@ -355,6 +399,35 @@ namespace dgt.power.codegeneration.Services
             return Regex.Replace(classId.ToUpperInvariant(), "[{}]", "", RegexOptions.NonBacktracking);
         }
 
+        /// <summary>
+        /// Generate quick view form class so it matches with the mapped form name
+        /// </summary>
+        /// <param name="quickViewFormId"></param>
+        /// <param name="allForms"></param>
+        /// <returns></returns>
+        private static string GetQuickViewFormClass(string quickViewFormId, List<FormDetail> allForms)
+        {
+            var quickViewForm = allForms.FirstOrDefault(x => x.FormId != null && x.FormId.ToString() == quickViewFormId);
+            if (quickViewForm != null)
+            {
+                return MapFormClass(quickViewForm);
+            }
+            return "Xrm.Controls.QuickFormControl";
+        }
+
+        /// <summary>
+        /// Map quick view form class name
+        /// </summary>
+        /// <param name="form"></param>
+        /// <returns></returns>
+        private static string MapFormClass(FormDetail form)
+        {
+            var schemaName = Formatter.CamelCase(form.FormEntityName);
+            var formType = Formatter.CamelCase(Formatter.Sanitize((form.FormTypeName)));
+            var formName = Formatter.CamelCase(Formatter.Sanitize(form.FormUniqueName));
+            return $"XrmForm.{schemaName}.{formType}.{formName}.QuickFormControl";
+        }
+
         public static string FormatFormType(string formType)
         {
              return formType
@@ -363,7 +436,7 @@ namespace dgt.power.codegeneration.Services
                 .Replace("quickcreate", "Quick Create");
         }
 
-        public static string GetFormType(int type)
+        public static string GetFormType(int? type)
         {
             return type switch
             {

--- a/src/modules/dgt.power.codegeneration/Services/MetadataService.cs
+++ b/src/modules/dgt.power.codegeneration/Services/MetadataService.cs
@@ -748,6 +748,7 @@ public class MetadataService : IMetadataService
             var formScope = $"{entityLogicalName}.{form.Type?.Value}";
             return FormParser.ParseForm(form,
                 Unique(form.GetAttributeValue<string>(SystemForm.LogicalNames.Name).Trim(), formScope),
+                entityLogicalName,
                 bpfControls);
         })
        .ToDictionary(formDetail => $"{formDetail.FormUniqueName}.{FormParser.GetFormType(formDetail.FormType)}", formDetail => formDetail);

--- a/src/modules/dgt.power.codegeneration/Templates/CustomLiquidFilters.cs
+++ b/src/modules/dgt.power.codegeneration/Templates/CustomLiquidFilters.cs
@@ -80,7 +80,7 @@ public static class CustomLiquidFilters
 #pragma warning restore IDE0060 // Remove unused parameter
     {
         return new StringValue(GetAttributeByLogicalName(input, arguments).RequiredLevel);
-    }    
+    }
     public static ValueTask<FluidValue> XrmMockAttributetype(FluidValue input, FilterArguments arguments, TemplateContext context)
 #pragma warning disable IDE0060 // Remove unused parameter
     {
@@ -117,8 +117,23 @@ public static class CustomLiquidFilters
     public static ValueTask<FluidValue> GetControlTypeFromFormControl(FluidValue input, FilterArguments arguments, TemplateContext context)
 #pragma warning restore IDE0060 // Remove unused parameter
     {
-        return new StringValue(GetControlByControlName(input, arguments).DefinitelyTypedControlType);
-    }  
+        return new StringValue(GetControlByControlName(input, arguments)?.DefinitelyTypedControlType);
+    }
+
+    public static ValueTask<FluidValue> IsAttributeInList(FluidValue input, FilterArguments arguments, TemplateContext context)
+    {
+        var value = input.ToStringValue();
+        var result = QueryAttributeByLogicalName(value, arguments);
+        return BooleanValue.Create(result != null);
+    }
+
+#pragma warning disable IDE0060 // Remove unused parameter
+    public static ValueTask<FluidValue> GetAttributeItem(FluidValue input, FilterArguments arguments, TemplateContext context)
+#pragma warning disable IDE0060 // Remove unused parameter
+    {
+        return new ObjectValue(GetAttributeByLogicalName(input, arguments));
+    }
+
 
     private static FormControlViewModel? GetControlByControlName(FluidValue input, FilterArguments arguments)
     {
@@ -131,8 +146,19 @@ public static class CustomLiquidFilters
 
     private static AttributeMetadataViewModel GetAttributeByLogicalName(FluidValue input, FilterArguments arguments)
     {
-        var scope = arguments.At(0).ToObjectValue();
         var value = input.ToStringValue();
+        var result = QueryAttributeByLogicalName(value, arguments);
+        if (result != null)
+        {
+            return result;
+        }
+        AnsiConsole.MarkupLine($"[red]Warning:[/] cant find Attributemetadata for: {value}");
+        return new AttributeMetadataViewModel(new AttributeMetadata{LogicalName = value});
+    }  
+
+    private static AttributeMetadataViewModel? QueryAttributeByLogicalName(string? value, FilterArguments arguments)
+    {
+        var scope = arguments.At(0).ToObjectValue();
 
         var attr = new List<AttributeMetadataViewModel>(((object[])scope).Cast<AttributeMetadataViewModel>());
         var result = attr.SingleOrDefault(s => s.LogicalName == value);
@@ -140,8 +166,6 @@ public static class CustomLiquidFilters
         {
             return result;
         }
-
-        AnsiConsole.MarkupLine($"[red]Warning:[/] cant find Attributemetadata for: {value}");
-        return new AttributeMetadataViewModel(new AttributeMetadata{LogicalName = value});
+        return null;
     }
 }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/CustomApi.liquid
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/CustomApi.liquid
@@ -1,6 +1,6 @@
 ﻿// Automatically generated typings file https://github.com/DIGITALLNature/DigitallPower
 /* eslint-disable */
-{%- assign CustomApiName = Name  | sanitize | camelcase -%}
+{%- assign CustomApiName = Name  | sanitize | camelcase %}
 declare namespace XrmCustomApi.{{ CustomApiName }} {
     export const enum CustomApiEnums {
         LogicalName = "{{ Name }}"
@@ -14,7 +14,7 @@ declare namespace XrmCustomApi.{{ CustomApiName }} {
     {%- endif %}
 
     {%- if OutParameters.size > 0 %}
-    export interface Response {
+    export interface Response extends XrmWebApi.ExecuteResponse {
         {% for outParameter in OutParameters  %}
         {{ outParameter.ParameterName }}{%- if outParameter.IsOptional %}?{%- endif %}: {{ outParameter.ParameterType }};{% endfor %}
     }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/Entity.liquid
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/Entity.liquid
@@ -17,7 +17,23 @@ declare namespace XrmTable.{{ SchemaName | camelcase }} {
     {% endfor -%}
     }
 
-    export interface DTO {
+    export const enum AttributeTypes {
+    {%- for attr in Attributes  %}
+        {{ attr.SchemaName | sanitize | camelcase | unique: "M"  }} =  "{{ attr.DefinitelyType }}",
+    {%- endfor %}
+    }
+
+    export const enum LogicalNames {
+    {%- for attr in Attributes  %}
+        {{ attr.SchemaName | sanitize | camelcase | unique: "A"  }} =  "{{ attr.LogicalName }}",
+    {%- endfor %}
+    }
+
+    export const enum Entity {
+        LogicalName = "{{ LogicalName }}",
+    }
+
+    export interface DTO extends XrmTable.DTO.TableFields<LogicalNames> {
     {%- for attr in Attributes  %}
         {%- if attr.DefinitelyType == "Lookup" %}
         "_{{ attr.LogicalName }}_value@OData.Community.Display.V1.FormattedValue"?: string;
@@ -41,22 +57,6 @@ declare namespace XrmTable.{{ SchemaName | camelcase }} {
         {%- else %}
         {{ attr.LogicalName }}?: {{ attr.NativeType }};
         {%- endif %}
-    {%- endfor %}
-    }
-
-    export const enum Entity {
-        LogicalName = "{{ LogicalName }}",
-    }
-
-    export const enum AttributeTypes {
-    {%- for attr in Attributes  %}
-        {{ attr.SchemaName | sanitize | camelcase | unique: "M"  }} =  "{{ attr.DefinitelyType }}",
-    {%- endfor %}
-    }
-
-    export const enum LogicalNames {
-    {%- for attr in Attributes  %}
-        {{ attr.SchemaName | sanitize | camelcase | unique: "A"  }} =  "{{ attr.LogicalName }}",
     {%- endfor %}
     }
 

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/EntityForm.liquid
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/EntityForm.liquid
@@ -1,39 +1,62 @@
 // Automatically generated typings file https://github.com/DIGITALLNature/DigitallPower
 /* eslint-disable */
 
-{% assign FormName = FormDetail.FormUniqueName  | sanitize | camelcase -%}
+{%- assign FormName = FormDetail.FormUniqueName  | sanitize | camelcase -%}
 {%- assign FormType = FormDetail.FormTypeName  | sanitize | camelcase -%}
-
+{%- assign FormEntityName = FormDetail.FormEntityName | camelcase -%}
+{%- assign HasAnyControl = false %}{%- if FormDetail.FormControls.size > 0 or FormDetail.HeaderControlFields.size > 0 or BpfControls.size > 0 -%}{%- assign HasAnyControl = true %}{%- endif %}
+{%- assign HasAnyAttribute = false %}{%- if FormDetail.Attributes.size > 0 -%}{%- assign HasAnyAttribute = true %}{%- endif %}
+{%- assign HasAnyTab = false %}{%- if FormDetail.TabDetails.size > 0 -%}{%- assign HasAnyTab = true %}{%- endif %}
+{%- assign HasAnySection = false %}{% assign tabSections = FormDetail.TabDetails | map: "Sections" | map: "size" | join: "" -%}
+{%- if tabSections != "" and tabSections != "0" -%}{%- assign HasAnySection = true %}{%- endif %}
 declare namespace Xrm.Events {
     export interface EventContext {
         getFormContext<{{ FormName }}FormContext>(): {{ FormName }}FormContext;
     }
 }
 
-declare namespace XrmForm.{{ EntitySchemaName | camelcase }} {
+declare namespace XrmForm.{{ FormEntityName }} {
     namespace {{ FormType }}.{{ FormName }} {
         export const enum FormData {
             FormId = "{{ FormDetail.FormId }}",
         }
 
-        export interface FormContext extends Xrm.FormContext {
-            getAttribute<T extends Xrm.Attributes.Attribute>(name: FormAttributeName): T | null;
-            getAttribute(name: string): Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues> | null;
-            getAttribute<T extends Xrm.Attributes.Attribute>(name: string): T | null;
-            getAttribute(delegateFunction?: Xrm.Collection.MatchingDelegate<Xrm.Attributes.Attribute>): Xrm.Attributes.Attribute[];
-            {% for attribute in FormDetail.Attributes  %}
-            getAttribute(name: "{{ attribute.DataFieldName }}"): {{ attribute.DataFieldName | attributetype: Attributes }}{%- if attribute.IsOptionalAttribute %} | null{%- endif %};{% endfor %}
-
-            getControl<T extends Xrm.Controls.Control>(name: string): T | null;
-            getControl(delegateFunction?: Xrm.Collection.MatchingDelegate<Xrm.Controls.Control>): Xrm.Controls.Control[];
-            getControl(name: string): Xrm.Controls.Control | null;
-
+        {% if HasAnyControl == true -%}
+        export type ControlName =
             {% for formControl in FormDetail.FormControls  %}
-            getControl(name: "{{ formControl.ControlName }}"): {{ formControl.DefinitelyTypedControlType }};{% endfor %}
+            | "{{ formControl.ControlName }}"{%- endfor %}
             {% for headerField in FormDetail.HeaderControlFields  %}
-            getControl(name: "header_{{ headerField }}"): {{ headerField | controltype: Attributes }};{% endfor %}
+            | "header_{{ headerField }}"{%- endfor %}
             {% for bpfControl in BpfControls %}
+            | "header_process_{{ bpfControl.DataFieldName }}"{%- endfor -%};{%- endif %}
+        {% if HasAnyAttribute == true %}
+        export type AttributeName = 
+            {%- for attribute in FormDetail.Attributes  %}
+            | "{{ attribute.DataFieldName }}"{% endfor %};{%- endif %}
+
+        export interface FormContext extends Xrm.FormContext {
+            {%- for attribute in FormDetail.Attributes  %}
+            getAttribute(name: "{{ attribute.DataFieldName }}"): {{ attribute.DataFieldName | attributetype: Attributes }}{%- if attribute.IsOptionalAttribute %} | null{%- endif %};{% endfor %}
+            {%- if HasAnyAttribute == true -%}
+            getAttribute(name: AttributeName): Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues> | null;
+            getAttribute<T extends Xrm.Attributes.Attribute>(name: AttributeName): T | null;
+            getAttribute<T>(name: string): T | null;
+            {%- endif %}
+            getAttribute(delegateFunction?: Xrm.Collection.MatchingDelegate<Xrm.Attributes.Attribute>): Xrm.Attributes.Attribute[];
+            
+            {%- for formControl in FormDetail.FormControls  %}
+            getControl(name: "{{ formControl.ControlName }}"): {{ formControl.DefinitelyTypedControlType }};{% endfor %}
+            {%- for headerField in FormDetail.HeaderControlFields  %}
+            getControl(name: "header_{{ headerField }}"): {{ headerField | controltype: Attributes }};{% endfor %}
+            {%- for bpfControl in BpfControls %}
             getControl(name: "header_process_{{ bpfControl.DataFieldName }}"): {{ bpfControl.DefinitelyTypedControlType }} | null;{% endfor %}
+            {% if HasAnyControl == true -%}
+            getControl(name: ControlName): Xrm.Controls.Control | null;
+            getControl<T extends Xrm.Controls.Control>(name: ControlName): T | null;
+            getControl<T>(name: string): T | null;
+            {%- endif %}
+            getControl(delegateFunction?: Xrm.Collection.MatchingDelegate<Xrm.Controls.Control>): Xrm.Controls.Control[];
+
             ui: Ui;
             data: Data;
         }
@@ -56,27 +79,44 @@ declare namespace XrmForm.{{ EntitySchemaName | camelcase }} {
         export interface Attributes extends Xrm.Collection.ItemCollection<Xrm.Attributes.Attribute<Xrm.Attributes.Attribute.AttributeValues>> {
             {%- for attribute in FormDetail.Attributes  %}
             get(name: "{{ attribute.DataFieldName }}"): {{ attribute.DataFieldName | attributetype: Attributes }};{% endfor %}
-            get<T extends Xrm.Attributes.Attribute>(name: string): T | null;
-            get(name: string): Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues> | null;
+            get(name: AttributeName): Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues> | null;
+            get<T extends Xrm.Attributes.Attribute<Xrm.Attributes.Attribute.AttributeValues>>(name: AttributeName): T | null;
+            get<T>(name: string): T | null;
             get(delegate?: MatchingDelegate<Xrm.Attributes.Attribute<Xrm.Attributes.Attribute.AttributeValues>>): Xrm.Attributes.Attribute<Xrm.Attributes.Attribute.AttributeValues>[];
         }
 
         export interface Controls extends Xrm.Collection.ItemCollection<Xrm.Controls.Control> {
             {%- for formControl in FormDetail.FormControls  %}
             get(name: "{{ formControl.ControlName }}"): {{ formControl.DefinitelyTypedControlType }};{% endfor %}
-            get<T extends Xrm.Controls.Control>(name: string): T | null;
-            get(name: string): Xrm.Controls.Control | null;
+            get(name: ControlName): Xrm.Controls.Control | null;
+            get<T extends Xrm.Controls.Control>(name: ControlName): T | null;
+            get<T>(name: string): T | null;
             get(delegate?: MatchingDelegate<Xrm.Controls.Control>): Xrm.Controls.Control[];
         }
+
+        {% if FormDetail.TabDetails.size > 0 %}
+        export type TabName = 
+            {%- for tab in FormDetail.TabDetails  %}
+            | "{{ tab.TabName }}"{% endfor %};{%- endif %}
+
+        {% if HasAnySection == true -%}
+        export type SectionNames = 
+            {%- for tab in FormDetail.TabDetails  %}{% for section in tab.Sections  %}
+            | "{{section.SectionName}}"{% endfor %}{% endfor %};
+        {% endif %}
 
         export interface Tabs extends Xrm.Collection.ItemCollection<Xrm.Controls.Tab> {
             {% for tab in FormDetail.TabDetails  %}{%- assign TabName = tab.TabName | sanitize | camelcase -%}
             get(itemName: "{{ tab.TabName }}"): {{ TabName }};
             {% endfor %}
-            get<T extends Xrm.Controls.Tab>(name: string): T | null;
-            get(name: string): Xrm.Controls.Tab | null;
+            {% if FormDetail.TabDetails.size > 0 %}
+            get(name: TabName): Xrm.Controls.Tab | null;
+            get<T extends Xrm.Controls.Tab>(name: TabName): T | null;
+            get<T>(name: string): T | null;
+            {%- endif %}
             get(delegate?: Xrm.Collection.MatchingDelegate<Xrm.Controls.Tab>): Xrm.Controls.Tab[];
         }
+
         {% for tab in FormDetail.TabDetails  %}{%- assign TabName = tab.TabName | sanitize | camelcase -%}
         export interface {{ TabName }} extends Xrm.Controls.Tab {
             sections: {{ TabName }}Sections;
@@ -84,31 +124,47 @@ declare namespace XrmForm.{{ EntitySchemaName | camelcase }} {
 
         export interface {{ TabName }}Sections extends Xrm.Collection.ItemCollection<Xrm.Controls.Section> {
             {% for section in tab.Sections  %}
-            {%- assign SectionName = section.SectionName | sanitize | camelcase %}get(name: "{{ section.SectionName }}"): {{ TabName }}{{ SectionName }};{% endfor -%}
+            {%- assign SectionName = section.SectionName | sanitize | camelcase %}
+            get(name: "{{ section.SectionName }}"): {{ TabName }}{{ SectionName }};{% endfor -%}
             get<T extends Xrm.Controls.Section>(name: string): T | null;
             get(name: string): Xrm.Controls.Section | null;
             get(): Xrm.Controls.Section[];
         }
         {% for section in tab.Sections  %}{%- assign SectionName = section.SectionName | sanitize | camelcase %}
+        {% if section.ControlNames.size > 0 %}
+        export type {{ TabName }}{{ SectionName }}ControlName = 
+            {%- for sectionControlName in section.ControlNames  %}
+            | "{{ sectionControlName }}"{% endfor %};{%- endif %}
+
         export interface {{ TabName }}{{ SectionName }} extends Xrm.Controls.Section {
             {%- for controlName in section.ControlNames %}
             get(name: "{{ controlName }}"): {{ controlName | formControlType: FormDetail.FormControls }}; {%- endfor %}
-            get<T extends Xrm.Controls.Control>(name: string): T | null;
-            get(name: string): Xrm.Controls.Control | null;
+            {% if section.ControlNames.size > 0 %}
+            get(name: {{ TabName }}{{ SectionName }}ControlName): T | null;
+            get<T extends Xrm.Controls.Control>(name: {{ TabName }}{{ SectionName }}ControlName): T | null;
+            get<T>(name: string): T | null;
+            {%- endif %}
             get(): Xrm.Controls.Control[];
         }
         {% endfor %}{% endfor %}
 
+        {% if FormDetail.QuickViews.size > 0 %}
+        export type QuickFormControlNames = 
+            {%- for quickViewControl in FormDetail.QuickViews  %}
+            | "{{ quickViewControl.ControlName }}"{% endfor %};{%- endif %}
+
         export interface QuickForms extends Xrm.Collection.ItemCollection<Xrm.Controls.QuickFormControl> {
-            get<T extends Xrm.Controls.QuickFormControl>(name: string): T | null;
-            get(name: string): Xrm.Controls.QuickFormControl | null;
+            {%- for quickViewControl in FormDetail.QuickViews %}
+            get(name: "{{ quickViewControl.ControlName }}"): {{ quickViewControl.QuickViewFormClass }};{% endfor %}
+            {% if FormDetail.QuickViews.size > 0 %}
+            get(name: QuickFormControlNames): Xrm.Controls.QuickFormControl | null;
+            get<T extends Xrm.Controls.QuickFormControl>(name: QuickFormControlNames): T | null;
+            {%- endif %}
+            get<T>(name: string): T | null;
             get(): Xrm.Controls.QuickFormControl[];
-            {%- for quickViewName in FormDetail.QuickViews %}
-            get(name: "{{ quickViewName }}"): Xrm.Controls.QuickFormControl;{% endfor %}
         }
 
         {%- if FormType == "QuickView" %}
-
         export interface QuickFormControl extends Xrm.Controls.QuickFormControl {
             {%- for formControl in FormDetail.FormControls  %}
             getControl(name: "{{ formControl.ControlName }}"): {{ formControl.DefinitelyTypedControlType }};{% endfor %}
@@ -118,6 +174,11 @@ declare namespace XrmForm.{{ EntitySchemaName | camelcase }} {
             getControl(name: "header_process_{{ bpfControl.DataFieldName }}"): {{ bpfControl.DefinitelyTypedControlType }} | null;{% endfor %}
             {%- for subgrid in FormDetail.Grids %}
             getControl(name: "{{ subgrid }}"): Xrm.Controls.GridControl;{% endfor %}
+            {% if HasAnyControl == true -%}
+            getControl(name: ControlName): Xrm.Controls.Control | null;
+            getControl<T extends Xrm.Controls.Control>(name: ControlName): T | null;{%- endif %}
+            getControl<T>(name: string): T | null;
+            getControl(): Xrm.Control.Control[] | null;
         }
         {%- endif %}
     }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/EntityFormTestHelper.liquid
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/EntityFormTestHelper.liquid
@@ -1,58 +1,92 @@
 // Automatically generated typings file https://github.com/DIGITALLNature/DigitallPower
 /* eslint-disable */
 
-{% assign FormName = FormDetail.FormUniqueName  | sanitize | camelcase -%}
+{%- assign FormName = FormDetail.FormUniqueName  | sanitize | camelcase -%}
 {%- assign FormType = FormDetail.FormTypeName  | sanitize | camelcase -%}
+{%- assign FormEntityName = FormDetail.FormEntityName | camelcase -%}
+{%- assign FormClassNamespace = "XrmForm." | append: FormEntityName | append: "." | append: FormType | append: "." | append: FormName -%}
+{%- assign HasAnyControl = false %}{%- if FormDetail.FormControls.size > 0 or FormDetail.HeaderControlFields.size > 0 or BpfControls.size > 0 -%}{%- assign HasAnyControl = true %}{%- endif %}
+{%- assign HasAnyAttribute = false %}{%- if FormDetail.Attributes.size > 0 -%}{%- assign HasAnyAttribute = true %}{%- endif %}
+{%- assign HasAnyTab = false %}{%- if FormDetail.TabDetails.size > 0 -%}{%- assign HasAnyTab = true %}{%- endif %}
+{%- assign HasAnySection = false %}{% assign tabSections = FormDetail.TabDetails | map: "Sections" | map: "size" | join: "" -%}
+{%- if tabSections != "" and tabSections != "0" -%}{%- assign HasAnySection = true %}{%- endif %}
 
-
-export namespace XrmForm{{ EntitySchemaName | camelcase }}{{FormType}}{{FormName}}TestHelper {
+export namespace XrmForm{{ FormEntityName }}{{FormType}}{{FormName}}TestHelper {
+    {% if HasAnyControl == true %}
     export const FormControlNames: string[] = [
-        {%- for formControl in FormDetail.FormControls  %}
-        "{{ formControl.ControlName }}",{% endfor %}
+        {% for formControl in FormDetail.FormControls  %}
+        "{{ formControl.ControlName }}",{%- endfor %}
         {% for headerField in FormDetail.HeaderControlFields  %}
-        "header_{{ headerField }}",{% endfor -%}
+        "header_{{ headerField }}",{%- endfor %}
         {% for bpfControl in BpfControls %}
-        "header_process_{{ bpfControl.DataFieldName }}",{% endfor %}
-    ] as const;
+        "header_process_{{ bpfControl.DataFieldName }}",{%- endfor %}
+    ] as const;{% endif %}
 
-    export const FormControlTypesConfig: XrmForm.Tester.XrmFormMockControl[] = [
+    {% if HasAnyAttribute == true -%}
+    export const FormAttributeNames: string[] = [
+        {% for attribute in FormDetail.Attributes  %}
+        "{{ attribute.DataFieldName }}",{%- endfor %}
+    ] as const;{%- endif %}
+
+    {% if HasAnyControl == true %}{% if HasAnyAttribute == true -%}
+    export const FormControlTypesConfig: XrmForm.Tester.XrmFormMockControl<{{FormClassNamespace}}.ControlName, {{FormClassNamespace}}.AttributeName>[] = [
+    {%- else -%}
+    export const FormControlTypesConfig: XrmForm.Tester.XrmFormMockControl<{{FormClassNamespace}}.ControlName, string>[] = [{%- endif %}
         {%- for formControl in FormDetail.FormControls  %}
         {
             name: "{{ formControl.ControlName }}",
-            type: "{{ formControl.MockXrmControlType }}", // formControl
+            {%- if formControl.AttributeName != blank %}
+            attributeName: "{{ formControl.AttributeName }}",
+            {%- endif %}
+            type: "{{ formControl.MockXrmControlType }}",
             isVisible: {{ formControl.IsVisible }},
             isDisabled: {{ formControl.IsDisabled }},
-        },{% endfor %}{% for headerField in FormDetail.HeaderControlFields  %}
+        },{%- endfor %}{% for headerField in FormDetail.HeaderControlFields  %}
         {
             name: "header_{{ headerField }}",
             type: "{{ headerField | xrmMockControlType: Attributes }}", // HeaderControl
             attributeName: "{{ headerField }}",
-        },{% endfor -%}{% for bpfControl in BpfControls %}
+        },{%- endfor %}{% for bpfControl in BpfControls %}
         {
             name: "header_process_{{ bpfControl.DataFieldName }}",
-            type: "{{ bpfControl.XrmMockControlType }}",//bpfControl
+            type: "{{ bpfControl.XrmMockControlType }}", //bpfControl
+            attributeName: "{{ bpfControl.DataFieldName }}",
         },{% endfor %}
-    ] as const;
-
-    export const FormAttributeNames: string[] = [
-        {%- for attribute in FormDetail.Attributes  %}
-        "{{ attribute.DataFieldName }}",{% endfor %}
-    ] as const;
-
-    export const FormAttributeTypesConfig: XrmForm.Tester.XrmFormMockAttribute[] = [
+    ] as const;{%- endif %}
+    {% if HasAnyAttribute == true %}
+    export const FormAttributeTypesConfig: XrmForm.Tester.XrmFormMockAttribute<{{FormClassNamespace}}.AttributeName>[] = [
         {%- for attribute in FormDetail.Attributes  %}{
+            {% assign AtttributeType = attribute.DataFieldName | xrmMockAttributeType: Attributes -%}
             name: "{{ attribute.DataFieldName }}",
-            type: "{{ attribute.DataFieldName | xrmMockAttributeType: Attributes }}",
+            type: "{{ AtttributeType }}",
             requiredLevel: "{{ attribute.DataFieldName | requiredAttributeLevel: Attributes }}",
+            {% if AtttributeType == "optionSet" or AtttributeType == "multiSet" %}{% assign enumAttribute = attribute.DataFieldName | getAttributeItem: EnumAttributes -%}
+            options: [{% for option in enumAttribute.Options  %}
+            {
+                text: "{{ option.Label | localize: LanguageCode | sanitize | camelcase   }}",
+                value: {{ option.Value }},
+            }, {% endfor %}
+            ],{% endif %}
         },{% endfor %}
-    ];
-
+    ];{%- endif %}
+    {% if HasAnyTab == true %}
     export const TabNames: string[] = [
-        {% for tab in FormDetail.TabDetails  %}"{{ tab.TabName }}",
-        {% endfor %}
+        {% for tab in FormDetail.TabDetails  %}"{{ tab.TabName }}",{% endfor %}
     ] as const;
-
-    export const TabSectionControlsConfig: XrmForm.Tester.XrmFormMockTab[] = [
+    {% if HasAnySection == true %}
+    export const SectionNames: string[] = [{% for tab in FormDetail.TabDetails  %}{% for section in tab.Sections  %}
+        "{{section.SectionName}}",{% endfor %}{% endfor %}
+    ] as const;{%- endif %}
+    {% if HasAnyTab == true and HasAnyControl == true and HasAnySection == true %}
+    export const TabSectionControlsConfig: XrmForm.Tester.XrmFormMockTab<{{FormClassNamespace}}.TabName, {{FormClassNamespace}}.SectionNames, {{FormClassNamespace}}.ControlName>[]
+    {%- elsif HasAnyTab == true and HasAnyControl == true -%}
+    export const TabSectionControlsConfig: XrmForm.Tester.XrmFormMockTab<{{FormClassNamespace}}.TabName, string, {{FormClassNamespace}}.ControlName>[]
+    {%- elsif  HasAnyControl == true -%}
+    export const TabSectionControlsConfig: XrmForm.Tester.XrmFormMockTab<string, string, {{FormClassNamespace}}.ControlName>[]
+    {%- else -%}
+    export const TabSectionControlsConfig: XrmForm.Tester.XrmFormMockTab<string, string, string>[]
+    {%- endif %}
+    = [
         {% for tab in FormDetail.TabDetails  %}
         {
             name: "{{ tab.TabName }}",
@@ -67,15 +101,6 @@ export namespace XrmForm{{ EntitySchemaName | camelcase }}{{FormType}}{{FormName
                     ],
                 },{% endfor %}
             ],
-        },{% endfor %}        
-    ];
-
-    export const SectionNames: string[] = [{% for tab in FormDetail.TabDetails  %}{% for section in tab.Sections  %}
-        "{{section.SectionName}}",{% endfor %}{% endfor %}
-    ];
-
-    export type ControlNameType = typeof FormControlNames[number];
-    export type AttributeNameType = typeof FormAttributeNames[number];
-    export type TabNameType = typeof TabNames[number];
-    export type SectionNameType = typeof SectionNames[number];
+        },{% endfor -%}
+    ];{%- endif %}
 }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/ViewModels/FormViewModel.cs
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/ViewModels/FormViewModel.cs
@@ -9,8 +9,8 @@ namespace dgt.power.codegeneration.Templates.tsl.ViewModels;
 public record FormViewModel
 {
     public required List<AttributeMetadata> Attributes { get; init; }
+    public IEnumerable<EnumAttributeMetadata> EnumAttributes => Attributes.OfType<EnumAttributeMetadata>();
     public required List<BpfControlDetail> BpfControls { get; init; }
-    public required string EntitySchemaName { get; init; }
     public required FormDetail FormDetail { get; init; }
     public required string Name { get; init; }
 }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_form_tester.d.ts
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_form_tester.d.ts
@@ -11,11 +11,11 @@ declare namespace XrmForm.Tester {
         | "string";
     export type XrmFormMockAttributeType = "boolean" | "date" | "lookup" | "multiSet" | "number" | "optionSet" | "string";
 
-    export interface XrmFormMockControl {
-        attributeName?: string;
+    export interface XrmFormMockControl<CtlNames extends string, AttNames extends string> {
+        attributeName?: AttNames;
         isVisible?: boolean;
         isDisabled?: boolean;
-        name: string;
+        name: CtlNames;
         type: XrmFormMockControlType;
     }
 
@@ -24,38 +24,31 @@ declare namespace XrmForm.Tester {
         valueString?: string;
         valueNumber?: number;
         valueDate?: Date;
-        valueLookup?: Xrm.LookupValue | Xrm.LookupValue[];
+        valueLookup?: Xrm.LookupValue[];
     }
 
-    export interface XrmFormMockAttributeControlUpdateBase {
-        isDisabled?: boolean;
-        isVisible?: boolean;
-        controlAttributeName: string;
-        controlSpecificName?: string;
-        requiredLevel?: XrmEnum.RequirementLevel;
+    export interface XrmFormMockAttribute<AttNames extends string> {
+        name: AttNames;
         value?: XrmMockAttributeValue;
-    }
-
-    export interface XrmFormMockAttribute {
-        name: string;
-        value?: XrmMockAttributeValue;
-        requiredLevel?: XrmEnum.RequirementLevel;
+        requiredLevel?: Xrm.Attributes.RequirementLevel;
         type: XrmFormMockAttributeType;
+        options?: Xrm.OptionSetValue[];
+        isDirty?: boolean;
     }
 
-    export interface XrmFormMockTabSection {
-        name: string;
+    export interface XrmFormMockTabSection<SectionNames extends string, CtlNames extends string> {
+        name: SectionNames;
         label?: string;
         isVisible?: boolean;
-        controlNames: string[];
+        controlNames: CtlNames[];
     }
-    export interface XrmFormMockTab {
-        name: string;
+    export interface XrmFormMockTab<TabNames extends string, SectionNames extends string, CtlNames extends string> {
+        name: TabNames;
         label?: string;
         isVisible?: boolean;
         displayState?: Xrm.DisplayState;
         parent?: Xrm.Ui;
-        sectionNames: string[];
-        sections: XrmFormMockTabSection[];
+        sectionNames: SectionNames[];
+        sections: XrmFormMockTabSection<SectionNames, CtlNames>[];
     }
 }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_odata_filter.ts
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_odata_filter.ts
@@ -1,0 +1,195 @@
+﻿import { defaultParser, Token, TokenType } from "@odata/parser";
+
+export type TokenValue = string | number | boolean | null | undefined | Date;
+export class XrmMockFormODataFilter {
+    // Map OData operators to JS logic
+    private static readonly ops: Record<string, (a: TokenValue, b: TokenValue) => boolean> = {
+        [TokenType.EqualsExpression]: (a, b) => {
+            if (
+                a === b ||
+                ((a === null || a === undefined) && (b === null || b === undefined)) ||
+                a?.toLocaleString() === b?.toLocaleString()
+            ) {
+                return true;
+            }
+            return false;
+        },
+        [TokenType.NotEqualsExpression]: (a, b) => a != b, // to consider null/undefined
+        [TokenType.GreaterThanExpression]: (a, b) => {
+            if (a === undefined || a === null || b === undefined || b === null) {
+                return false;
+            }
+            return a > b;
+        },
+        [TokenType.GreaterOrEqualsExpression]: (a, b) => {
+            if (a === undefined || a === null || b === undefined || b === null) {
+                return false;
+            }
+            return a >= b;
+        },
+        [TokenType.LesserThanExpression]: (a, b) => {
+            if (a === undefined || a === null || b === undefined || b === null) {
+                return false;
+            }
+            return a < b;
+        },
+        [TokenType.LesserOrEqualsExpression]: (a, b) => {
+            if (a === undefined || a === null || b === undefined || b === null) {
+                return false;
+            }
+            return a <= b;
+        },
+    };
+
+    public static executeRetrieveMultipleRecord(list: XrmTable.DTO.Table<string>[], oDataString: string): XrmTable.DTO.Table<string>[] {
+        try {
+            console.log(`Run next query in mock data ${oDataString}`);
+            const astObject = defaultParser.query(oDataString);
+            const astOptions = astObject.value.options ?? [];
+            const selectFields = XrmMockFormODataFilter.getSelectFieldNamesFromAstObject(astOptions);
+            const filterOption = XrmMockFormODataFilter.getFilterFromAstObject(astOptions);
+            if (!filterOption) {
+                return list.map((x) => XrmMockFormODataFilter.selectProperties(x, selectFields));
+            }
+            const filteredItems = list.filter((item) => XrmMockFormODataFilter.filterListItem(item, filterOption));
+            return filteredItems.map((x) => XrmMockFormODataFilter.selectProperties(x, selectFields));
+        } catch (error) {
+            console.error(`Failed to parse the OData query ${error}`);
+            return list;
+        }
+    }
+
+    /**
+     * Given an Item provide the
+     * @param item Table item into which we will apply the oData select
+     * @param oDataString oDataString with the select expression to apply to the table
+     * @returns
+     */
+    public static executeSelectSingleRecord(item: XrmTable.DTO.Table<string>, oDataString?: string): XrmTable.DTO.Table<string> {
+        if (!oDataString) {
+            // if no select return just the whole item
+            return item;
+        }
+        const ast = defaultParser.query(oDataString);
+        const astOptions = ast.value.options ?? [];
+        const selectFields = XrmMockFormODataFilter.getSelectFieldNamesFromAstObject(astOptions);
+        return XrmMockFormODataFilter.selectProperties(item, selectFields);
+    }
+
+    private static getSelectFieldNamesFromAstObject(astOptions: Token[]): string[] {
+        const selectFieldsToken: Token[] = astOptions.find((opt) => opt.type === TokenType.Select)?.value?.items ?? [];
+        return selectFieldsToken.map((x) => x.raw);
+    }
+
+    private static getFilterFromAstObject(astOptions: Token[]): Token | null {
+        return astOptions.find((opt) => opt.type === TokenType.Filter) ?? null;
+    }
+
+    private static selectProperties(listItem: XrmTable.DTO.Table<string>, returnKeys: string[]): XrmTable.DTO.Table<string> {
+        const result: XrmTable.DTO.Table<string> = {};
+        returnKeys.forEach((fieldName) => {
+            if (XrmMockFormODataFilter.isFieldNodeStartAndEndWithLimiters(fieldName, "_", "_value")) {
+                const dtoFieldName = XrmMockFormODataFilter.deleteRawNodeStartAndEnd(fieldName, "_", "_value");
+                const formattedFieldName = `${fieldName}@OData.Community.Display.V1.FormattedValue`;
+                const formattedDtoFieldName = `${dtoFieldName}_name_`;
+                result[fieldName] = listItem[dtoFieldName];
+                if (listItem[formattedDtoFieldName]) {
+                    result[formattedFieldName] = listItem[formattedDtoFieldName];
+                } else if (result[fieldName]) {
+                    result[formattedFieldName] = `name_${result[fieldName]}`;
+                }
+            } else {
+                result[fieldName] = listItem[fieldName];
+            }
+        });
+        return result;
+    }
+
+    private static filterListItem(item: XrmTable.DTO.Table<string>, filterQueryAst: Token): boolean {
+        return XrmMockFormODataFilter.evaluate(item, filterQueryAst.value);
+    }
+
+    private static evaluate(item: XrmTable.DTO.Table<string>, node: Token): boolean {
+        switch (node.type) {
+            case TokenType.AndExpression:
+                return XrmMockFormODataFilter.evaluate(item, node.value.left) && XrmMockFormODataFilter.evaluate(item, node.value.right);
+            case TokenType.OrExpression:
+                return XrmMockFormODataFilter.evaluate(item, node.value.left) || XrmMockFormODataFilter.evaluate(item, node.value.right);
+            case TokenType.NotExpression:
+                return !XrmMockFormODataFilter.evaluate(item, node.value);
+            case TokenType.EqualsExpression:
+            case TokenType.NotEqualsExpression:
+            case TokenType.GreaterThanExpression:
+            case TokenType.GreaterOrEqualsExpression:
+            case TokenType.LesserThanExpression:
+            case TokenType.LesserOrEqualsExpression:
+                return XrmMockFormODataFilter.ops[node.type](
+                    XrmMockFormODataFilter.resolveValue(item, node.value.left),
+                    XrmMockFormODataFilter.resolveValue(item, node.value.right)
+                );
+            case TokenType.MethodCallExpression:
+                return XrmMockFormODataFilter.handleFunction(item, node);
+
+            default:
+                return true;
+        }
+    }
+
+    private static resolveValue(item: XrmTable.DTO.Table<string>, node: Token): TokenValue {
+        // assumption all expression have fields as first value in the expression
+        if (node.type === TokenType.FirstMemberExpression) {
+            const fieldName = XrmMockFormODataFilter.convertNodeToFieldName(node);
+            if (typeof fieldName === "string" && item[fieldName] !== undefined) {
+                return item[fieldName];
+            }
+        }
+        if (node.raw == "null") {
+            return null;
+        }
+        if (node.type == TokenType.Literal && typeof node.raw === "string") {
+            return XrmMockFormODataFilter.deleteRawNodeStartAndEnd(node.raw, "'", "'");
+        }
+        return node.raw;
+    }
+
+    private static convertNodeToFieldName(node: Token): TokenValue {
+        if (typeof node.raw === "string") {
+            return XrmMockFormODataFilter.deleteRawNodeStartAndEnd(node.raw, "_", "_value");
+        }
+        return node.raw;
+    }
+
+    private static deleteRawNodeStartAndEnd(nodeRaw: string, startLimiter: string, endLimiter: string): string {
+        if (XrmMockFormODataFilter.isFieldNodeStartAndEndWithLimiters(nodeRaw, startLimiter, endLimiter)) {
+            return nodeRaw.substring(nodeRaw.indexOf(startLimiter) + 1, nodeRaw.lastIndexOf(endLimiter));
+        }
+        return nodeRaw;
+    }
+
+    private static isFieldNodeStartAndEndWithLimiters(nodeRaw: string, startLimiter: string, endLimiter: string): boolean {
+        return nodeRaw.startsWith(startLimiter) && nodeRaw.endsWith(endLimiter);
+    }
+
+    private static handleFunction(item: XrmTable.DTO.Table<string>, node: Token): boolean {
+        // Resolve arguments (e.g., the property value and the literal string)
+        if (!!node.value.parameters && node.value.parameters.length > 1) {
+            const fieldName: string | null = node.value?.parameters?.[0]?.raw ?? null;
+            const fieldValue: string | null = node.value?.parameters?.[1]?.raw ?? null;
+            const operator = node.value.method;
+            if (fieldName && fieldValue) {
+                const target = item[fieldName];
+                switch (operator) {
+                    case "contains":
+                        return target?.toLocaleString().includes(fieldValue) ?? false;
+                    case "startswith":
+                        return target?.toLocaleString().startsWith(fieldValue) ?? false;
+                    case "endswith":
+                        return target?.toLocaleString().endsWith(fieldValue) ?? false;
+                    default:
+                        return false;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_test_context_builder.ts
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_test_context_builder.ts
@@ -3,7 +3,10 @@ import {
     BooleanControlMock,
     DateAttributeMock,
     DateControlMock,
+    EntityMock,
     EventContextMock,
+    FormItemMock,
+    IEntityComponents,
     ItemCollectionMock,
     LookupAttributeMock,
     LookupControlMock,
@@ -15,17 +18,49 @@ import {
     StringControlMock,
     TabMock,
     XrmMockGenerator,
+    DataMock,
 } from "xrm-mock";
 import { EventContextWithEventArgsMock } from "xrm-mock/dist/xrm-mock/events/eventcontextwitheventargs.mock";
-import { IXrmMockFormTestContextBuilder, XrmMockAttributeType, XrmMockControlType } from "./xrm_mock_form_test_context_types";
+import {
+    IXrmMockFormTestContextBuilder,
+    XrmCustomApiMockData,
+    XrmFormMockAttributeControlUpdateBase,
+    XrmFormMockServerData,
+    XrmMockAttributeType,
+    XrmMockConfirmDialogResponses,
+    XrmMockControlType,
+    XrmMockUiNotification,
+    XrmNavigationMockStubs,
+    XrmUtilityApiMockStubs,
+    XrmWebApiMockStubs,
+    XrmWebApiOnlineMockStubs,
+} from "./xrm_mock_form_test_context_types";
+import { XrmMockFormODataFilter } from "./xrm_mock_form_odata_filter";
 
 /** Auxiliary class for simplified xrm-mock testing */
-export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBuilder {
-    private readonly mockAttributes: Map<string, XrmMockAttributeType>;
-    private readonly mockControls: Map<string, XrmMockControlType>;
-    private readonly controlConfig: XrmForm.Tester.XrmFormMockControl[];
-    private readonly attributeConfig: XrmForm.Tester.XrmFormMockAttribute[];
-    private readonly tabConfig: XrmForm.Tester.XrmFormMockTab[];
+export class XrmMockFormTestContextBuilder<
+    TTabNames extends string,
+    TSectionNames extends string,
+    TControlName extends string,
+    TAttributeNames extends string,
+> implements IXrmMockFormTestContextBuilder<TControlName, TAttributeNames>
+{
+    public static readonly ERROR_NO_CUSTOM_API = "Bad Request";
+    public xrmWebApiMockStubs: XrmWebApiMockStubs = {};
+    public xrmWebApiOnlineMockStubs: XrmWebApiOnlineMockStubs = {};
+    public xrmNavigationMockStubs: XrmNavigationMockStubs = {};
+    public xrmUiNotificationsMocks: XrmMockUiNotification = {};
+    public xrmUtilityApiMockStubs: XrmUtilityApiMockStubs = {};
+    private formEntity: IEntityComponents = {};
+    private formType: XrmEnum.FormType = XrmEnum.FormType.Create; //default value
+    private confirmDialogConfirmedSeq: XrmMockConfirmDialogResponses[] = [];
+    private readonly mockAttributes: Map<TAttributeNames, XrmMockAttributeType>;
+    private readonly mockControls: Map<TControlName, XrmMockControlType>;
+    private readonly controlConfig: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>[];
+    private readonly attributeConfig: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>[];
+    private readonly tabConfig: XrmForm.Tester.XrmFormMockTab<TTabNames, TSectionNames, TControlName>[];
+    private readonly serverMockData: XrmFormMockServerData = {};
+    private readonly serverCustomApiMockData: XrmCustomApiMockData = {};
 
     /**
      * @summary Default constructor function
@@ -34,23 +69,22 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
      * @param initialTabsConfig Configuration for tab/section/controls
      */
     constructor(
-        initialControlsConfig: XrmForm.Tester.XrmFormMockControl[],
-        initialAttributesConfig: XrmForm.Tester.XrmFormMockAttribute[],
-        initialTabsConfig: XrmForm.Tester.XrmFormMockTab[]
+        initialControlsConfig: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>[],
+        initialAttributesConfig: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>[],
+        initialTabsConfig: XrmForm.Tester.XrmFormMockTab<TTabNames, TSectionNames, TControlName>[]
     ) {
         // Gets inputs from the generated files with the form description
-        this.mockAttributes = new Map<string, XrmMockAttributeType>();
-        this.mockControls = new Map<string, XrmMockControlType>();
+        this.mockAttributes = new Map<TAttributeNames, XrmMockAttributeType>();
+        this.mockControls = new Map<TControlName, XrmMockControlType>();
         this.controlConfig = [...initialControlsConfig];
         this.attributeConfig = [...initialAttributesConfig];
         this.tabConfig = initialTabsConfig;
     }
-
     /**
      * @summary Simple function to get the correctly mapped load event with arguments to pass to form load
      * @returns the mock load event to be passed to the onload form event
      */
-    public GetLoadExecutionContext(): EventContextWithEventArgsMock<Xrm.Events.LoadEventArguments> {
+    public getLoadExecutionContext(): EventContextWithEventArgsMock<Xrm.Events.LoadEventArguments> {
         const eventContext = XrmMockGenerator.getEventContext() ?? new EventContextMock({});
         const eventArgs: Xrm.Events.LoadEventArguments = {
             getDataLoadState: () => XrmEnum.FormDataLoadState.InitialLoad,
@@ -67,27 +101,250 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
     }
 
     /**
-     * Modifies the default form context config with the given update data
-     * @param updateData Simply array with the control/attributes to be changed
-     * @returns the object itself
+     * Given the form context config and data it generates the xrm-mock form, needs to be called before the test starts
+     * @returns The object itself
      */
-    public WithData(updateData: XrmForm.Tester.XrmFormMockAttributeControlUpdateBase[]): this {
-        this.UpdateControlConfig(updateData);
+    public buildMockFormContext(): this {
+        XrmMockGenerator.initialise({
+            entity: this.formEntity,
+            process: undefined,
+        });
+        (XrmMockGenerator.formContext.ui.formSelector.getCurrentItem() as FormItemMock).formType = this.formType;
+        this.InitializeMockFormContextControls();
+        this.InitTabs();
+        this.InitXrmNavigationApiMocks();
+        if (this.serverMockData) {
+            this.InitXrmWebApiServerMocks();
+        }
+        if (this.serverCustomApiMockData) {
+            this.InitXrmWebApiOnlineMocks();
+        }
+        this.InitUiNotificationMocks();
+        this.InitXrmUtilityMocks();
         return this;
     }
 
     /**
-     * Given the form context config and data it generates the xrm-mock form, needs to be called before the test starts
-     * @returns The object itself
+     * Modifies the default form context config with the given update data
+     * @param updateData Simply array with the control/attributes to be changed
+     * @returns the object itself
      */
-    public BuildMockFormContext(): this {
-        XrmMockGenerator.initialise();
-        this.InitializeMockFormContextControls();
-        this.InitTabs();
+    public withFormData(updateData: XrmFormMockAttributeControlUpdateBase<TControlName, TAttributeNames>[]): this {
+        this.UpdateControlConfig(updateData);
         return this;
     }
 
-    private UpdateControlConfig(updateAttributes: XrmForm.Tester.XrmFormMockAttributeControlUpdateBase[]): void {
+    /***
+     * Set the entity id of the form so it is returned when calling entity.GetId()
+     * @param recordId unique id of the form entity
+     */
+    public withEntityId(entityName: string, entityId: string): this {
+        this.formEntity = {
+            entityName,
+            id: entityId,
+        };
+        return this;
+    }
+
+    /**
+     * To set the form type on creation
+     * @param formType Form type of the form context
+     * @returns
+     */
+    public withFormType(formType: XrmEnum.FormType): this {
+        this.formType = formType;
+        return this;
+    }
+
+    /**
+     * Setup a fake server data to be returned by the sino stubs
+     * @param data Simple array of entity lists to be a fake for stubs to return
+     */
+    public withServerData(data: XrmFormMockServerData): this {
+        Object.assign(this.serverMockData, data);
+        return this;
+    }
+
+    /**
+     * Configure the custom api mock data that the test context builder will contain
+     * @param data Object containing a map of custom api names and the mock responses
+     * @returns
+     */
+    public withCustomApi(data: XrmCustomApiMockData): this {
+        Object.assign(this.serverCustomApiMockData, data);
+        return this;
+    }
+
+    /**
+     * Configure the sequence of confirm cancel dialog response for the form context calls
+     * @param confirmDialogConfirmed
+     */
+    public withUserConfirmDialogSeq(confirmDialogConfirmed: boolean[]): this {
+        this.confirmDialogConfirmedSeq = confirmDialogConfirmed.map((x) => ({ confirmed: x, executed: false }));
+        return this;
+    }
+
+    /**
+     * Get mock control in context out of the name string
+     * @param controlName
+     * @returns
+     */
+    public getControl<T extends XrmMockControlType>(controlName: TControlName): T | null {
+        return <T>this.mockControls.get(controlName) ?? null;
+    }
+
+    /**
+     * Get mock attribute in context out of the name string
+     * @param attributeName
+     * @returns
+     */
+    public getAttribute<T extends XrmMockAttributeType>(attributeName: TAttributeNames): T | null {
+        return <T>this.mockAttributes.get(attributeName) ?? null;
+    }
+
+    private InitXrmWebApiServerMocks(): void {
+        this.xrmWebApiMockStubs = {
+            retrieveMultipleRecords: jest.fn((entityLogicalName: string, options?: string, maxPageSize?: number) =>
+                this.RetrieveMultipleRecords(entityLogicalName, options, maxPageSize)
+            ),
+            retrieveRecord: jest.fn((entityLogicalName: string, id: string, options?: string) =>
+                this.RetrieveSingleStubRecord(entityLogicalName, id, options)
+            ),
+            createRecord: jest.fn((entityLogicalName: string, record: XrmTable.DTO.Table<string>) => ({
+                entityLogicalName,
+                id: crypto.randomUUID(),
+            })),
+        };
+        jest.spyOn(Xrm.WebApi, "retrieveRecord").mockImplementation(this.xrmWebApiMockStubs.retrieveRecord);
+        jest.spyOn(Xrm.WebApi, "retrieveMultipleRecords").mockImplementation(this.xrmWebApiMockStubs.retrieveMultipleRecords);
+        jest.spyOn(Xrm.WebApi, "createRecord").mockImplementation(this.xrmWebApiMockStubs.createRecord);
+    }
+
+    private InitXrmWebApiOnlineMocks(): void {
+        this.xrmWebApiOnlineMockStubs = {
+            execute: jest.fn(
+                (request: XrmWebApi.ExecuteRequest): Xrm.Async.PromiseLike<Response> => this.GetCustomApiMockResponse(request)
+            ),
+        };
+        jest.spyOn(Xrm.WebApi.online, "execute").mockImplementation(this.xrmWebApiOnlineMockStubs.execute);
+    }
+
+    private InitXrmNavigationApiMocks(): void {
+        this.xrmNavigationMockStubs = {
+            openAlertDialog: jest.fn((_alertStrings: Xrm.Navigation.AlertStrings, _alertOptions?: Xrm.Navigation.DialogSizeOptions) => {
+                return Promise.resolve() as unknown as Xrm.Async.PromiseLike<void>;
+            }),
+            openConfirmDialog: jest.fn(
+                (_confirmString: Xrm.Navigation.ConfirmStrings, confirmOptions?: Xrm.Navigation.DialogSizeOptions) => {
+                    const item = this.confirmDialogConfirmedSeq.find((x) => !x.executed);
+                    if (item) {
+                        item.executed = true;
+                    }
+                    /// no dialog seq provided for this dialog... return false by default
+                    return Promise.resolve({
+                        confirmed: item?.confirmed ?? false,
+                    }) as unknown as Xrm.Async.PromiseLike<Xrm.Navigation.ConfirmResult>;
+                }
+            ),
+        };
+        jest.spyOn(Xrm.Navigation, "openAlertDialog").mockImplementation(this.xrmNavigationMockStubs.openAlertDialog);
+        jest.spyOn(Xrm.Navigation, "openConfirmDialog").mockImplementation(this.xrmNavigationMockStubs.openConfirmDialog);
+    }
+
+    private InitUiNotificationMocks(): void {
+        this.xrmUiNotificationsMocks = {
+            setFormNotification: jest.fn((_message: string, _level: Xrm.FormNotificationLevel, _uniqueId: string): boolean => {
+                return true;
+            }),
+            clearFormNotification: jest.fn((_uniqueId: string): void => { }),
+        };
+        const formContext = XrmMockGenerator.getFormContext();
+        if (this.xrmUiNotificationsMocks.setFormNotification) {
+            formContext.ui.setFormNotification = this.xrmUiNotificationsMocks.setFormNotification;
+        }
+        if (this.xrmUiNotificationsMocks.clearFormNotification) {
+            formContext.ui.clearFormNotification = this.xrmUiNotificationsMocks.clearFormNotification;
+        }
+    }
+
+    private InitXrmUtilityMocks(): void {
+        this.xrmUtilityApiMockStubs = {
+            closeProgressIndicator: jest.fn(),
+            showProgressIndicator: jest.fn(),
+        };
+        jest.spyOn(Xrm.Utility, "closeProgressIndicator").mockImplementation(this.xrmUtilityApiMockStubs.closeProgressIndicator);
+        jest.spyOn(Xrm.Utility, "showProgressIndicator").mockImplementation(this.xrmUtilityApiMockStubs.showProgressIndicator);
+    }
+
+    private RetrieveMultipleRecords(
+        entityLogicalName: string,
+        options?: string,
+        _maxPageSize?: number
+    ): Xrm.Async.PromiseLike<Xrm.RetrieveMultipleResult<XrmTable.DTO.Table<string>>> {
+        const entityDTOs = this.serverMockData[entityLogicalName];
+        if (!entityDTOs) {
+            return Promise.resolve({
+                entities: [],
+                nextLink: "",
+            }) as unknown as Xrm.Async.PromiseLike<Xrm.RetrieveMultipleResult<XrmTable.DTO.Table<string>>>;
+        }
+        if (!options) {
+            return Promise.resolve({
+                entities: [...entityDTOs],
+                nextLink: "",
+            }) as unknown as Xrm.Async.PromiseLike<Xrm.RetrieveMultipleResult<XrmTable.DTO.Table<string>>>;
+        }
+        const oDataQueryString = options?.startsWith("?") ? options.substring(1) : options;
+        const mockFilterResults = XrmMockFormODataFilter.executeRetrieveMultipleRecord(entityDTOs, oDataQueryString);
+        return Promise.resolve({
+            entities: [...mockFilterResults],
+            nextLink: "",
+        }) as unknown as Xrm.Async.PromiseLike<Xrm.RetrieveMultipleResult<XrmTable.DTO.Table<string>>>;
+    }
+
+    private RetrieveSingleStubRecord(
+        entityLogicalName: string,
+        id: string,
+        options?: string
+    ): Xrm.Async.PromiseLike<Partial<XrmTable.DTO.Table<string>>> {
+        const entity = this.serverMockData[entityLogicalName];
+        if (!entity) {
+            throw new Error(`No record not found for entity ${entityLogicalName}`);
+        }
+        const record = entity.find((x) => x[`${entityLogicalName}id`] === id);
+        if (!record) {
+            throw new Error(`Record not found for entity ${entityLogicalName} with ${id}`);
+        }
+        if (options) {
+            const oDataQueryString = options?.startsWith("?") ? options.substring(1) : options;
+            return Promise.resolve(
+                XrmMockFormODataFilter.executeSelectSingleRecord(record, oDataQueryString)
+            ) as unknown as Xrm.Async.PromiseLike<Partial<XrmTable.DTO.Table<string>>>;
+        }
+        return Promise.resolve(record) as unknown as Xrm.Async.PromiseLike<Partial<XrmTable.DTO.Table<string>>>;
+    }
+
+    private GetCustomApiMockResponse(request: XrmWebApi.ExecuteRequest): Xrm.Async.PromiseLike<Response> {
+        const apiName = request.getMetadata().operationName;
+        try {
+            if (apiName) {
+                const webApiResponse = this.serverCustomApiMockData[apiName];
+                if (webApiResponse) {
+                    return Promise.resolve(new Response(JSON.stringify(webApiResponse))) as unknown as Xrm.Async.PromiseLike<Response>;
+                }
+            }
+            return Promise.resolve(
+                new Response(JSON.stringify({ error: "no response for received request " }), {
+                    status: 400,
+                    statusText: XrmMockFormTestContextBuilder.ERROR_NO_CUSTOM_API,
+                })
+            ) as unknown as Xrm.Async.PromiseLike<Response>;
+        } catch (error: any) {
+            throw new Error(error?.message);
+        }
+    }
+
+    private UpdateControlConfig(updateAttributes: XrmFormMockAttributeControlUpdateBase<TControlName, TAttributeNames>[]): void {
         for (const updateData of updateAttributes) {
             const control = this.controlConfig.find((x) => {
                 if (updateData.controlSpecificName) {
@@ -110,7 +367,7 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
 
     private InitializeMockFormContextControls(): void {
         for (const attribute of this.attributeConfig) {
-            const attributeMock = XrmMockFormTestContextBuilder.CreateXrmMockFakeAttribute(attribute.name, attribute);
+            const attributeMock = this.CreateXrmMockFakeAttribute(attribute.name, attribute);
             if (attributeMock) {
                 this.mockAttributes.set(attribute.name, attributeMock);
             }
@@ -123,9 +380,14 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
         }
         const formContext = XrmMockGenerator.getFormContext();
         const attributes = [...this.mockAttributes.values()];
-        formContext.data.attributes = new ItemCollectionMock<Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>>(
-            <Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>[]>attributes
-        );
+        const entityMock = new EntityMock({
+            ...this.formEntity,
+            attributes: new ItemCollectionMock<Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>>(
+                <Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>[]>attributes
+            ),
+        });
+        formContext.data = new DataMock(entityMock);
+        formContext.data.getIsDirty = this.getIsDirty.bind(this);
     }
 
     private InitTabs(): this {
@@ -135,7 +397,7 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
         return this;
     }
 
-    private InitTab(tab: XrmForm.Tester.XrmFormMockTab): this {
+    private InitTab(tab: XrmForm.Tester.XrmFormMockTab<TTabNames, TSectionNames, TControlName>): this {
         const mockTab = XrmMockGenerator.Tab.createTab(tab.name, tab.label, tab.isVisible, tab.displayState, tab.parent);
         for (const tabSection of tab.sections) {
             this.InitTabSection(mockTab, tabSection);
@@ -143,7 +405,7 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
         return this;
     }
 
-    private InitTabSection(tab: TabMock, section: XrmForm.Tester.XrmFormMockTabSection): this {
+    private InitTabSection(tab: TabMock, section: XrmForm.Tester.XrmFormMockTabSection<TSectionNames, TControlName>): this {
         const controls = this.FilterControlList(section.controlNames);
         const controlCollection: ItemCollectionMock<Xrm.Controls.Control> = new ItemCollectionMock<Xrm.Controls.Control>(
             <Xrm.Controls.Control[]>controls
@@ -152,7 +414,7 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
         return this;
     }
 
-    private FilterControlList(controlNames: string[]): XrmMockControlType[] {
+    private FilterControlList(controlNames: TControlName[]): XrmMockControlType[] {
         return (
             controlNames
                 .map((name) => this.mockControls.get(name))
@@ -162,9 +424,9 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
         );
     }
 
-    private static CreateXrmMockFakeAttribute(
+    private CreateXrmMockFakeAttribute(
         name: string,
-        mockAttribute: XrmForm.Tester.XrmFormMockAttribute
+        mockAttribute: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>
     ): XrmMockAttributeType | null {
         switch (mockAttribute.type) {
             case "string":
@@ -173,16 +435,37 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
                     value: mockAttribute.value?.valueString,
                 });
             case "boolean":
-                return XrmMockGenerator.Attribute.createBoolean({ name, value: mockAttribute.value?.valueBoolean });
+                return XrmMockGenerator.Attribute.createBoolean({
+                    name,
+                    value: mockAttribute.value?.valueBoolean,
+                    isDirty: mockAttribute?.isDirty,
+                });
             case "date":
-                return XrmMockGenerator.Attribute.createDate({ name, value: mockAttribute.value?.valueDate });
+                return XrmMockGenerator.Attribute.createDate({
+                    name,
+                    value: mockAttribute.value?.valueDate,
+                    isDirty: mockAttribute?.isDirty,
+                });
             case "number":
-                return XrmMockGenerator.Attribute.createNumber({ name, value: mockAttribute.value?.valueNumber });
+                return XrmMockGenerator.Attribute.createNumber({
+                    name,
+                    value: mockAttribute.value?.valueNumber,
+                    isDirty: mockAttribute?.isDirty,
+                });
             case "lookup":
-                return XrmMockGenerator.Attribute.createLookup(name, mockAttribute.value?.valueLookup);
+                return XrmMockGenerator.Attribute.createLookup({
+                    name,
+                    value: mockAttribute.value?.valueLookup ?? null,
+                    isDirty: mockAttribute?.isDirty,
+                });
             case "optionSet":
             case "multiSet":
-                return XrmMockGenerator.Attribute.createOptionSet(name, mockAttribute.value?.valueNumber);
+                return XrmMockGenerator.Attribute.createOptionSet({
+                    name,
+                    value: mockAttribute.value?.valueNumber,
+                    options: mockAttribute.options ?? [],
+                    isDirty: mockAttribute?.isDirty,
+                });
             // case "Xrm.Controls.GridControl":
             // case "Xrm.Controls.KbSearchControl":
             // case "Xrm.Control.QuickFormControl":
@@ -193,22 +476,25 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
         }
     }
 
-    private CreateXrmMockFakeControl(name: string, control: XrmForm.Tester.XrmFormMockControl): XrmMockControlType | null {
+    private CreateXrmMockFakeControl(
+        name: string,
+        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
+    ): XrmMockControlType | null {
         const mockAttribute = control.attributeName ? this.mockAttributes.get(control.attributeName) : null;
         switch (control.type) {
             case "string":
-                return XrmMockFormTestContextBuilder.CreateStringMockControl(mockAttribute, control);
+                return this.CreateStringMockControl(mockAttribute, control);
             case "boolean":
-                return XrmMockFormTestContextBuilder.CreateBooleanMockControl(mockAttribute, control);
+                return this.CreateBooleanMockControl(mockAttribute, control);
             case "date":
-                return XrmMockFormTestContextBuilder.CreateDateMockControl(mockAttribute, control);
+                return this.CreateDateMockControl(mockAttribute, control);
             case "number":
-                return XrmMockFormTestContextBuilder.CreateNumberMockControl(mockAttribute, control);
+                return this.CreateNumberMockControl(mockAttribute, control);
             case "lookup":
-                return XrmMockFormTestContextBuilder.CreateLookupControl(mockAttribute, control);
+                return this.CreateLookupControl(mockAttribute, control);
             case "optionSet":
             case "multiSet":
-                return XrmMockFormTestContextBuilder.CreateOptionSetControl(mockAttribute, control);
+                return this.CreateOptionSetControl(mockAttribute, control);
             case "gridControl":
                 return XrmMockGenerator.Control.createGrid(name);
             case "quickView":
@@ -226,9 +512,9 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
         }
     }
 
-    private static CreateStringMockControl(
+    private CreateStringMockControl(
         mockAttribute: XrmMockAttributeType | null | undefined,
-        control: XrmForm.Tester.XrmFormMockControl
+        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
     ): StringControlMock | null {
         if (mockAttribute && control.attributeName) {
             return XrmMockGenerator.Control.createString({
@@ -240,9 +526,9 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
         return null;
     }
 
-    private static CreateBooleanMockControl(
+    private CreateBooleanMockControl(
         mockAttribute: XrmMockAttributeType | null | undefined,
-        control: XrmForm.Tester.XrmFormMockControl
+        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
     ): BooleanControlMock | null {
         if (mockAttribute && control.attributeName) {
             return XrmMockGenerator.Control.createBoolean({
@@ -254,9 +540,9 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
         return null;
     }
 
-    private static CreateDateMockControl(
+    private CreateDateMockControl(
         mockAttribute: XrmMockAttributeType | null | undefined,
-        control: XrmForm.Tester.XrmFormMockControl
+        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
     ): DateControlMock | null {
         if (mockAttribute && control.attributeName) {
             return XrmMockGenerator.Control.createDate({
@@ -268,9 +554,9 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
         return null;
     }
 
-    private static CreateNumberMockControl(
+    private CreateNumberMockControl(
         mockAttribute: XrmMockAttributeType | null | undefined,
-        control: XrmForm.Tester.XrmFormMockControl
+        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
     ): NumberControlMock | null {
         if (mockAttribute && control.attributeName) {
             return XrmMockGenerator.Control.createNumber({
@@ -282,9 +568,9 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
         return null;
     }
 
-    private static CreateLookupControl(
+    private CreateLookupControl(
         mockAttribute: XrmMockAttributeType | null | undefined,
-        control: XrmForm.Tester.XrmFormMockControl
+        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
     ): LookupControlMock | null {
         if (mockAttribute && control.attributeName) {
             return XrmMockGenerator.Control.createLookup({
@@ -296,9 +582,9 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
         return null;
     }
 
-    private static CreateOptionSetControl(
+    private CreateOptionSetControl(
         mockAttribute: XrmMockAttributeType | null | undefined,
-        control: XrmForm.Tester.XrmFormMockControl
+        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
     ): OptionSetControlMock | null {
         if (mockAttribute && control.attributeName) {
             return XrmMockGenerator.Control.createOptionSet({
@@ -308,5 +594,9 @@ export class XrmMockFormTestContextBuilder implements IXrmMockFormTestContextBui
             });
         }
         return null;
+    }
+
+    private getIsDirty() {
+        return Array.from(this.mockAttributes).some(([name, attr]) => attr.isDirty);
     }
 }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_test_context_types.ts
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_test_context_types.ts
@@ -32,8 +32,46 @@ export type XrmMockControlType =
     | OptionSetControlMock
     | StringControlMock;
 
-export interface IXrmMockFormTestContextBuilder {
-    GetLoadExecutionContext(): EventContextWithEventArgsMock<Xrm.Events.LoadEventArguments>;
-    WithData(updateData: XrmForm.Tester.XrmFormMockAttributeControlUpdateBase[]): this;
-    BuildMockFormContext(): this;
+export type XrmMockUiNotificationMethods = "setFormNotification" | "clearFormNotification";
+
+export type XrmMockUiNotification = Partial<Record<XrmMockUiNotificationMethods, jest.Mock>>;
+
+export interface XrmMockConfirmDialogResponses {
+    confirmed: boolean;
+    executed: boolean;
+}
+
+export interface XrmFormMockAttributeControlUpdateBase<CtlNames extends string, AttNames extends string> {
+    isDisabled?: boolean;
+    isVisible?: boolean;
+    controlAttributeName: AttNames;
+    controlSpecificName?: CtlNames;
+    requiredLevel?: Xrm.Attributes.RequirementLevel;
+    value?: XrmForm.Tester.XrmMockAttributeValue;
+}
+
+export type XrmFormMockServerData = Record<string, XrmTable.DTO.Table<string>[]>;
+export type XrmCustomApiMockData = Record<string, XrmWebApi.ExecuteResponse>;
+
+export type XrmWebApiMockStubMethods = jest.FunctionPropertyNames<Required<Xrm.WebApi>>;
+export type XrmWebApiOnlineMockStubMethod = jest.FunctionPropertyNames<Required<Xrm.WebApiOnline>>;
+export type XrmNavigationApiMockStubMethods = jest.FunctionPropertyNames<Required<Xrm.Navigation>>;
+export type XrmUtilityApiMockStubMethod = jest.FunctionPropertyNames<Required<Xrm.Utility>>;
+
+export type XrmWebApiMockStubs = Partial<Record<XrmWebApiMockStubMethods, jest.Mock>>;
+export type XrmWebApiOnlineMockStubs = Partial<Record<XrmWebApiOnlineMockStubMethod, jest.Mock>>;
+export type XrmNavigationMockStubs = Partial<Record<XrmNavigationApiMockStubMethods, jest.Mock>>;
+export type XrmUtilityApiMockStubs = Partial<Record<XrmUtilityApiMockStubMethod, jest.Mock>>;
+
+export interface IXrmMockFormTestContextBuilder<TControlNames extends string, TAttributeNames extends string> {
+    buildMockFormContext(): this;
+    getAttribute<T extends XrmMockAttributeType>(attributeName: TAttributeNames): T | null;
+    getControl<T extends XrmMockControlType>(controlName: TControlNames): T | null;
+    getLoadExecutionContext(): EventContextWithEventArgsMock<Xrm.Events.LoadEventArguments>;
+    withEntityId(entityName: string, entityId: string): this;
+    withFormData(updateData: XrmFormMockAttributeControlUpdateBase<TControlNames, TAttributeNames>[]): this;
+    withFormType(type: XrmEnum.FormType): this;
+    withUserConfirmDialogSeq(confirmDialogConfirmed: boolean[]): this;
+    withServerData(data: XrmFormMockServerData): this;
+    withCustomApi(data: XrmCustomApiMockData): this;
 }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_types_ext.d.ts
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_types_ext.d.ts
@@ -1,0 +1,3 @@
+﻿declare namespace XrmTable.DTO {
+    export type Table<FieldNames extends string> = Record<FieldNames, number | string | number | boolean | null | undefined>;
+}

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_webapi_ext.d.ts
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_webapi_ext.d.ts
@@ -51,6 +51,8 @@
         getMetadata(): WebApiMetadataObject;
     }
 
+    export interface ExecuteResponse { }
+
     export const enum WebApiOperationType {
         Action = 0,
         Function = 1,

--- a/src/modules/dgt.power.codegeneration/dgt.power.codegeneration.csproj
+++ b/src/modules/dgt.power.codegeneration/dgt.power.codegeneration.csproj
@@ -107,8 +107,8 @@
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.10" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client.Dynamics" Version="1.2.10" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
-    <PackageReference Include="System.CodeDom" Version="10.0.1" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Include="System.CodeDom" Version="10.0.3" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -225,11 +225,16 @@
     <None Remove="Templates\tsl\EntityFormTestHelper.liquid" />
     <EmbeddedResource Include="Templates\tsl\xrm_webapi_ext.d.ts" />
     <None Remove="Templates\tsl\EntityFormTestHelper.liquid" />
-    <EmbeddedResource Include="Templates\tsl\xrm_mock_form.d.ts" />
+    <EmbeddedResource Include="Templates\tsl\xrm_types_ext.d.ts" />
+    <None Remove="Templates\tsl\xrm_types_ext.ts" />
+    <EmbeddedResource Include="Templates\tsl\xrm_form_tester.d.ts" />
+    <None Remove="Templates\tsl\xrm_form_tester.ts" />
     <EmbeddedResource Include="Templates\tsl\xrm_mock_form_test_context_types.ts" />
     <None Remove="Templates\tsl\xrm_mock_form_test_context_types.ts" />
     <EmbeddedResource Include="Templates\tsl\xrm_mock_form_test_context_builder.ts" />
     <None Remove="Templates\tsl\xrm_mock_form_test_context_builder.ts" />
+    <EmbeddedResource Include="Templates\tsl\xrm_mock_form_odata_filter.ts" />
+    <None Remove="Templates\tsl\xrm_mock_form_odata_filter.ts" />
   </ItemGroup>
-
+ 
 </Project>

--- a/src/modules/dgt.power.export/dgt.power.export.csproj
+++ b/src/modules/dgt.power.export/dgt.power.export.csproj
@@ -20,7 +20,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0">
+	  <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/src/modules/dgt.power.import/dgt.power.import.csproj
+++ b/src/modules/dgt.power.import/dgt.power.import.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.4.1" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/modules/dgt.power.maintenance/dgt.power.maintenance.csproj
+++ b/src/modules/dgt.power.maintenance/dgt.power.maintenance.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/modules/dgt.power.profile/dgt.power.profile.csproj
+++ b/src/modules/dgt.power.profile/dgt.power.profile.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\dgt.power.common\dgt.power.common.csproj"/>
+    <ProjectReference Include="..\..\dgt.power.common\dgt.power.common.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/modules/dgt.power.push/dgt.power.push.csproj
+++ b/src/modules/dgt.power.push/dgt.power.push.csproj
@@ -11,10 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="dgt.registration" Version="1.0.1" />
-    <PackageReference Include="NuGet.Packaging" Version="7.0.1" />
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.1" />
+    <PackageReference Include="NuGet.Packaging" Version="7.3.0" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.3" />
     <PackageReference Include="UiPath.Workflow" Version="6.0.3" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/dgt.power.codegeneration.tests/TypescriptCommandTests.cs
+++ b/tests/dgt.power.codegeneration.tests/TypescriptCommandTests.cs
@@ -118,25 +118,24 @@ public class TypescriptCommandTests : CodeGenerationTestsBase<TypescriptCommand>
             .Execute(args)
             .Should().BeTrue();
 
-        var servicePath = $"{typescriptPath}/{FileNames.Typescript.Services}.ts";
+        var servicePath = $"{typescriptPath}/{FileNames.Typescript.FileNamePart.Services}.ts";
         File.Exists(servicePath);
         File.ReadAllText(servicePath).Should().Contain($@"/// <reference path=""{config.TypingPath}"" />");
 
 
-        var odataPath = $"{typescriptPath}/{FileNames.Typescript.Odata}.ts";
+        var odataPath = $"{typescriptPath}/{FileNames.Typescript.FileNamePart.Odata}.ts";
         File.Exists(odataPath);
         File.ReadAllText(odataPath).Should().Contain($@"/// <reference path=""{config.TypingPath}"" />");
 
-        var webapiPath = $"{typescriptPath}/{FileNames.Typescript.Webapi}.ts";
+        var webapiPath = $"{typescriptPath}/{FileNames.Typescript.FileNamePart.Webapi}.ts";
         File.Exists(webapiPath);
         File.ReadAllText(webapiPath).Should().Contain($@"/// <reference path=""{config.TypingPath}"" />");
 
-        var modelPath = $"{typescriptPath}/{FileNames.Typescript.Model}.ts";
+        var modelPath = $"{typescriptPath}/{FileNames.Typescript.FileNamePart.Model}.ts";
         File.Exists(modelPath);
         File.ReadAllText(modelPath).Should().Contain($@"/// <reference path=""{config.TypingPath}"" />");
 
-
-        var utilsPath = $"{typescriptPath}/{FileNames.Typescript.Utils}.ts";
+        var utilsPath = $"{typescriptPath}/{FileNames.Typescript.FileNamePart.Utils}.ts";
         File.Exists(utilsPath);
         File.ReadAllText(utilsPath).Should().Contain($@"/// <reference path=""{config.TypingPath}"" />");
     }
@@ -168,9 +167,9 @@ public class TypescriptCommandTests : CodeGenerationTestsBase<TypescriptCommand>
 
         var typescriptPath = GetArtifactPath($"{args.Folder}/{Folders.Typescript}");
 
-        File.Exists($"{typescriptPath}/{_accountMetadata.LogicalName}.{FileNames.Typescript.Entity}.ts").Should()
+        File.Exists($"{typescriptPath}/{_accountMetadata.LogicalName}.{FileNames.Typescript.FileNamePart.Entity}.ts").Should()
             .BeTrue();
-        File.Exists($"{typescriptPath}/{_accountMetadata.LogicalName}.{FileNames.Typescript.EntityRef}.ts").Should()
+        File.Exists($"{typescriptPath}/{_accountMetadata.LogicalName}.{FileNames.Typescript.FileNamePart.EntityRef}.ts").Should()
             .BeTrue();
     }
 
@@ -415,7 +414,7 @@ public class TypescriptCommandTests : CodeGenerationTestsBase<TypescriptCommand>
 
         var typescriptPath = GetArtifactPath($"{args.Folder}/{Folders.Typescript}");
 
-        File.Exists($"{typescriptPath}/{FileNames.Typescript.SdkMessageNames}.ts").Should().BeTrue();
+        File.Exists($"{typescriptPath}/{FileNames.Typescript.FileNames.SdkMessageNames}.ts").Should().BeTrue();
     }
 
     [Fact]
@@ -468,7 +467,7 @@ public class TypescriptCommandTests : CodeGenerationTestsBase<TypescriptCommand>
 
         var typescriptPath = GetArtifactPath($"{args.Folder}/{Folders.Typescript}");
 
-        var messagesPath = $"{typescriptPath}/{FileNames.Typescript.SdkMessageNames}.ts";
+        var messagesPath = $"{typescriptPath}/{FileNames.Typescript.FileNames.SdkMessageNames}.ts";
         File.Exists(messagesPath).Should().BeTrue();
         var messagesCode = File.ReadAllText(messagesPath);
         messagesCode.Should().Contain($"public static {Formatter.CamelCase(action.Name)}: string = \"{action.Name}\";");
@@ -504,7 +503,7 @@ public class TypescriptCommandTests : CodeGenerationTestsBase<TypescriptCommand>
 
         var typescriptPath = GetArtifactPath($"{args.Folder}/{Folders.Typescript}");
 
-        File.Exists($"{typescriptPath}/{FileNames.Typescript.SdkMessageNames}.ts")
+        File.Exists($"{typescriptPath}/{FileNames.Typescript.FileNames.SdkMessageNames}.ts")
             .Should()
             .BeFalse();
     }
@@ -541,7 +540,7 @@ public class TypescriptCommandTests : CodeGenerationTestsBase<TypescriptCommand>
 
         var typescriptPath = GetArtifactPath($"{args.Folder}/{Folders.Typescript}");
 
-        File.Exists($"{typescriptPath}/{FileNames.Typescript.OptionSetValues}.ts")
+        File.Exists($"{typescriptPath}/{FileNames.Typescript.FileNames.OptionSetValues}.ts")
             .Should()
             .BeTrue();
     }

--- a/tests/dgt.power.tests/dgt.power.tests.csproj
+++ b/tests/dgt.power.tests/dgt.power.tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.10" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.54.0" />
-    <PackageReference Include="System.Runtime.Caching" Version="10.0.1" />
+    <PackageReference Include="System.Runtime.Caching" Version="10.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Improve the ts generation class with extra classes
- Extend the ts form tester helper class with extra methods to emulate a web api calls, property that holds a list of a DTOs and the calls to the webapi retrieverecord/retrievemultiplerecord they will query in this DTOs with the user of a dummy ODT filter
- XrmMockFormODataFilter, implement a fake Odata filter, tried to cover different query scenarios from xrm
- Add extra hierarchy of constants in the file names
   - Entity
      - Entity
      - EntityForm
      - TestHelper
   - CustomApi
- Refactor the code to pass through the sonar checks about cognitive 
- Map the quickview form controls properly