### PR TITLE
feat(tsl): add type as branding property to distinguish them

### DIFF
--- a/src/modules/dgt.power.codegeneration/Templates/tsl/EntityForm.liquid
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/EntityForm.liquid
@@ -35,6 +35,7 @@ declare namespace XrmForm.{{ FormEntityName }} {
             | "{{ attribute.DataFieldName }}"{% endfor %};{%- endif %}
 
         export interface FormContext extends Xrm.FormContext {
+            __type: "{{FormEntityName}}.{{FormType}}.{{FormName}}";
             {%- for attribute in FormDetail.Attributes  %}
             getAttribute(name: "{{ attribute.DataFieldName }}"): {{ attribute.DataFieldName | attributetype: Attributes }}{%- if attribute.IsOptionalAttribute %} | null{%- endif %};{% endfor %}
             {%- if HasAnyAttribute == true -%}


### PR DESCRIPTION
- Add type branding property so when using generated classes an strict type check will find out wrong formcontext assignment to functions