### PR TITLE
fix: extend known namespaces list

### DIFF
--- a/src/modules/dgt.power.push/Logic/AssemblyModelBuilder.cs
+++ b/src/modules/dgt.power.push/Logic/AssemblyModelBuilder.cs
@@ -23,7 +23,7 @@ internal class AssemblyModelBuilder : IDisposable
 {
     private readonly DataContext _context;
 
-    private readonly string[] _knownNamespaces = { "D365.Extension.Registration", "DGT.Registrations", "dgt.registration", "Digitall.APower.Registration" };
+    private readonly string[] _knownNamespaces = { "D365.Extension.Registration", "DGT.Registrations", "dgt.registration", "Digitall.APower.Registration", "Digitall.Plugins.Registration" };
 
     private readonly string[] _knownPluginAttributes =
     {


### PR DESCRIPTION
discover plugin steps using the new `Digitall.Plugins.Registration` package