### PR TITLE
fix: release build failures and unused symbol warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       run: pnpm install --frozen-lockfile
 
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build --no-restore --configuration Release
 
     - name: Run Tests
-      run: dotnet test --no-build -- --output Detailed
+      run: dotnet test --no-build --configuration Release -- --output Detailed

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,7 +51,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: dotnet build --no-restore
+        run: dotnet build --no-restore --configuration Release
 
       - name: Run Tests
-        run: dotnet test --no-build -- --output Detailed
+        run: dotnet test --no-build --configuration Release -- --output Detailed

--- a/src/dgt.power.common/dgt.power.common.csproj
+++ b/src/dgt.power.common/dgt.power.common.csproj
@@ -21,9 +21,9 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="$(Configuration) != 'Release'">
+  <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-    <_Parameter1>dgt.power.tests</_Parameter1>
+    <_Parameter1>dgt.power.tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dd58806217d8819acb3b578e6db06a61f7622022a88ce2d405b94b26a78b191880b92719a99150cc55536f52e929eb02c26c18ccb06ff92f06987471a8cd37a8ba58996497f983028d582836e28a7c7aa04909baca865c7546d7dd9a78938cb1212bd122e60d90a1a851f79960dfb094bf709373072721b0bad7e31f76d52fd0</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/src/dgt.power/Program.cs
+++ b/src/dgt.power/Program.cs
@@ -17,6 +17,12 @@ using dgt.power.codegeneration.Services;
 using dgt.power.codegeneration.Services.Contracts;
 using dgt.power.common;
 using dgt.power.common.Commands;
+#pragma warning disable IDE0005 // Used in #if RELEASE block
+// ReSharper disable RedundantUsingDirective
+using dgt.power.common.Exceptions;
+using dgt.power.common.Extensions;
+// ReSharper restore RedundantUsingDirective
+#pragma warning restore IDE0005
 using dgt.power.common.FileAccess;
 using dgt.power.common.Logic;
 using dgt.power.export.Base;

--- a/src/modules/dgt.power.analyzer/dgt.power.analyzer.csproj
+++ b/src/modules/dgt.power.analyzer/dgt.power.analyzer.csproj
@@ -21,9 +21,9 @@
     <ProjectReference Include="..\..\dgt.power.common\dgt.power.common.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(Configuration) != 'Release'">
+  <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>dgt.power.analyzer.tests</_Parameter1>
+      <_Parameter1>dgt.power.analyzer.tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dd58806217d8819acb3b578e6db06a61f7622022a88ce2d405b94b26a78b191880b92719a99150cc55536f52e929eb02c26c18ccb06ff92f06987471a8cd37a8ba58996497f983028d582836e28a7c7aa04909baca865c7546d7dd9a78938cb1212bd122e60d90a1a851f79960dfb094bf709373072721b0bad7e31f76d52fd0</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/src/modules/dgt.power.codegeneration/dgt.power.codegeneration.csproj
+++ b/src/modules/dgt.power.codegeneration/dgt.power.codegeneration.csproj
@@ -34,9 +34,9 @@
     <EmbeddedResource Include="Templates\ts\D365EntityForm.liquid" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(Configuration) != 'Release'">
+  <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>dgt.power.codegeneration.tests</_Parameter1>
+      <_Parameter1>dgt.power.codegeneration.tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dd58806217d8819acb3b578e6db06a61f7622022a88ce2d405b94b26a78b191880b92719a99150cc55536f52e929eb02c26c18ccb06ff92f06987471a8cd37a8ba58996497f983028d582836e28a7c7aa04909baca865c7546d7dd9a78938cb1212bd122e60d90a1a851f79960dfb094bf709373072721b0bad7e31f76d52fd0</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/src/modules/dgt.power.export/dgt.power.export.csproj
+++ b/src/modules/dgt.power.export/dgt.power.export.csproj
@@ -9,9 +9,9 @@
 		<LangVersion>latestmajor</LangVersion>
 	</PropertyGroup>
 
-	<ItemGroup Condition="$(Configuration) != 'Release'">
+	<ItemGroup>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-			<_Parameter1>dgt.power.export.tests</_Parameter1>
+			<_Parameter1>dgt.power.export.tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dd58806217d8819acb3b578e6db06a61f7622022a88ce2d405b94b26a78b191880b92719a99150cc55536f52e929eb02c26c18ccb06ff92f06987471a8cd37a8ba58996497f983028d582836e28a7c7aa04909baca865c7546d7dd9a78938cb1212bd122e60d90a1a851f79960dfb094bf709373072721b0bad7e31f76d52fd0</_Parameter1>
 		</AssemblyAttribute>
 	</ItemGroup>
 

--- a/src/modules/dgt.power.maintenance/Logic/CreateWorkflowStateConfig.cs
+++ b/src/modules/dgt.power.maintenance/Logic/CreateWorkflowStateConfig.cs
@@ -41,7 +41,7 @@ public class CreateWorkflowStateConfig(
         var publishers = args.Publishers?.Split(',');
 
         // Do the actual work
-        await CollectWorkflowStatesAsync(solutions, publishers, args.Config, args.Detailed);
+        await CollectWorkflowStatesAsync(solutions, publishers, args.Config, args.Detailed, args.Overwrite);
 
         // Print table report if requested
         if (args.TableReport)
@@ -52,7 +52,7 @@ public class CreateWorkflowStateConfig(
         return Tracer.End(this, true);
     }
 
-    private async Task CollectWorkflowStatesAsync(string[]? solutions, string[]? publishers, string configFile, bool detailed)
+    private async Task CollectWorkflowStatesAsync(string[]? solutions, string[]? publishers, string configFile, bool detailed, bool overwrite)
     {
         await Console.Progress()
             .StartAsync(async ctx =>
@@ -161,7 +161,8 @@ public class CreateWorkflowStateConfig(
                 // Write config to file
                 Tracer.Log($"Writing config to {configFile}", TraceEventType.Verbose);
 
-                using var fileStream = new FileStream(configFile, FileMode.Create, FileAccess.Write, FileShare.None);
+                var fileMode = overwrite ? FileMode.Create : FileMode.CreateNew;
+                using var fileStream = new FileStream(configFile, fileMode, FileAccess.Write, FileShare.None);
                 await JsonSerializer.SerializeAsync(fileStream, config, _jsonSerializerOptions);
 
                 prepareConfigTask.Value = prepareConfigTask.MaxValue;

--- a/src/modules/dgt.power.maintenance/Logic/ProtectCalculatedFields.cs
+++ b/src/modules/dgt.power.maintenance/Logic/ProtectCalculatedFields.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) DIGITALL Nature. All rights reserved
 // DIGITALL Nature licenses this file to you under the Microsoft Public License.
 
-using System.Diagnostics;
 using dgt.power.common;
 using dgt.power.maintenance.Base;
 using Microsoft.Xrm.Sdk;
@@ -19,11 +18,13 @@ public sealed class ProtectCalculatedFields(
     : BaseMaintenance(tracer, connection, configResolver, console)
 {
     protected override Task<bool> InvokeAsync(MaintenanceVerb args, CancellationToken cancellationToken) =>
-        Task.FromResult(InvokeCore(args));
+        Task.FromResult(InvokeCore());
 
-    private bool InvokeCore(MaintenanceVerb args)
+    #pragma warning disable S1135 // Async migration tracked in todo.md
+    // TODO(async): migrate to IOrganizationServiceAsync2
+    #pragma warning restore S1135
+    private bool InvokeCore()
     {
-        Debug.Assert(args != null, nameof(args) + " != null");
         Tracer.Start(this);
         var updated = 0;
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,7 +1,8 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
-    <SignAssembly>False</SignAssembly>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)dgt.tests.snk</AssemblyOriginatorKeyFile>
     <StaticAnalysisCodeType>Test</StaticAnalysisCodeType>
   </PropertyGroup>
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'dgt.power.tests'">

--- a/tests/dgt.power.telemetry.tests/dgt.power.telemetry.tests.csproj
+++ b/tests/dgt.power.telemetry.tests/dgt.power.telemetry.tests.csproj
@@ -7,8 +7,6 @@
     <IsPackable>false</IsPackable>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest-minimum</AnalysisLevel>
-    <SignAssembly>True</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\dgt.tests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/dgt.power.tests/dgt.power.tests.csproj
+++ b/tests/dgt.power.tests/dgt.power.tests.csproj
@@ -29,19 +29,19 @@
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>dgt.power.codegeneration.tests</_Parameter1>
+      <_Parameter1>dgt.power.codegeneration.tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dd58806217d8819acb3b578e6db06a61f7622022a88ce2d405b94b26a78b191880b92719a99150cc55536f52e929eb02c26c18ccb06ff92f06987471a8cd37a8ba58996497f983028d582836e28a7c7aa04909baca865c7546d7dd9a78938cb1212bd122e60d90a1a851f79960dfb094bf709373072721b0bad7e31f76d52fd0</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>dgt.power.export.tests</_Parameter1>
+      <_Parameter1>dgt.power.export.tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dd58806217d8819acb3b578e6db06a61f7622022a88ce2d405b94b26a78b191880b92719a99150cc55536f52e929eb02c26c18ccb06ff92f06987471a8cd37a8ba58996497f983028d582836e28a7c7aa04909baca865c7546d7dd9a78938cb1212bd122e60d90a1a851f79960dfb094bf709373072721b0bad7e31f76d52fd0</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>dgt.power.import.tests</_Parameter1>
+      <_Parameter1>dgt.power.import.tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dd58806217d8819acb3b578e6db06a61f7622022a88ce2d405b94b26a78b191880b92719a99150cc55536f52e929eb02c26c18ccb06ff92f06987471a8cd37a8ba58996497f983028d582836e28a7c7aa04909baca865c7546d7dd9a78938cb1212bd122e60d90a1a851f79960dfb094bf709373072721b0bad7e31f76d52fd0</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>dgt.power.maintenance.tests</_Parameter1>
+      <_Parameter1>dgt.power.maintenance.tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dd58806217d8819acb3b578e6db06a61f7622022a88ce2d405b94b26a78b191880b92719a99150cc55536f52e929eb02c26c18ccb06ff92f06987471a8cd37a8ba58996497f983028d582836e28a7c7aa04909baca865c7546d7dd9a78938cb1212bd122e60d90a1a851f79960dfb094bf709373072721b0bad7e31f76d52fd0</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>dgt.power.scaffolding.tests</_Parameter1>
+      <_Parameter1>dgt.power.scaffolding.tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dd58806217d8819acb3b578e6db06a61f7622022a88ce2d405b94b26a78b191880b92719a99150cc55536f52e929eb02c26c18ccb06ff92f06987471a8cd37a8ba58996497f983028d582836e28a7c7aa04909baca865c7546d7dd9a78938cb1212bd122e60d90a1a851f79960dfb094bf709373072721b0bad7e31f76d52fd0</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Two fixes caught during/after release pipeline analysis.

### fix: add missing usings for AbstractPowerException in release build

The `#if RELEASE` block in `Program.cs` references `AbstractPowerException` and the `IsDerivedFrom`/`GetInnerException` extension methods from `dgt.power.common.Exceptions` and `dgt.power.common.Extensions`. These `using` directives were missing, so the code compiled fine in Debug (block skipped by preprocessor) but failed during semantic-release which builds with `--configuration Release`.

Also adds an explicit Release-mode build step in `checks.yml` so this class of issue is caught in CI before reaching the release pipeline.

### fix(maintenance): resolve redundant symbol warnings

- **ProtectCalculatedFields**: remove unused `args` parameter from `InvokeCore` (was only used in `Debug.Assert`, not in logic); also removes now-unused `System.Diagnostics` import
- **CreateWorkflowStateConfig**: wire up the `Overwrite` setting from `CreateWorkflowStateConfigSettings` — previously the property existed but `FileMode.Create` was always used, silently overwriting existing files; now uses `FileMode.CreateNew` unless `--overwrite` is passed