### PR TITLE
fix: replace Thread.Sleep with Task.Delay in async migration

### DIFF
--- a/src/dgt.power.common/Extensions/OrganizationServiceExtensions.cs
+++ b/src/dgt.power.common/Extensions/OrganizationServiceExtensions.cs
@@ -4,7 +4,9 @@
 using System.Diagnostics;
 using dgt.power.dataverse;
 using Microsoft.Crm.Sdk.Messages;
+using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Query;
 using Spectre.Console;
 
@@ -220,6 +222,71 @@ public static class OrganizationServiceExtensions
             return false;
         }
 
+        return true;
+    }
+
+    public static Task<bool> TryUpdateAsync(this IOrganizationServiceAsync2 service, Entity entity, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(service);
+        ArgumentNullException.ThrowIfNull(entity);
+        return TryUpdateCoreAsync(service, entity, cancellationToken);
+    }
+
+    private static async Task<bool> TryUpdateCoreAsync(IOrganizationServiceAsync2 service, Entity entity, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await service.ExecuteAsync(new UpdateRequest { Target = entity }, cancellationToken);
+            LogToConsole("updated", TraceEventType.Verbose);
+        }
+        catch (Exception e)
+        {
+            LogToConsole($"update failed {entity.Id:B}: {e.RootMessage()}", TraceEventType.Error);
+            return false;
+        }
+        return true;
+    }
+
+    public static Task<bool> TryDeleteAsync(this IOrganizationServiceAsync2 service, string name, Guid id, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(service);
+        return TryDeleteCoreAsync(service, name, id, cancellationToken);
+    }
+
+    private static async Task<bool> TryDeleteCoreAsync(IOrganizationServiceAsync2 service, string name, Guid id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await service.ExecuteAsync(new DeleteRequest { Target = new EntityReference(name, id) }, cancellationToken);
+            LogToConsole("deleted", TraceEventType.Verbose);
+        }
+        catch (Exception e)
+        {
+            LogToConsole($"delete failed {id:B}: {e.RootMessage()}", TraceEventType.Error);
+            return false;
+        }
+        return true;
+    }
+
+    public static Task<bool> TryCreateAsync(this IOrganizationServiceAsync2 service, Entity entity, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(service);
+        ArgumentNullException.ThrowIfNull(entity);
+        return TryCreateCoreAsync(service, entity, cancellationToken);
+    }
+
+    private static async Task<bool> TryCreateCoreAsync(IOrganizationServiceAsync2 service, Entity entity, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await service.ExecuteAsync(new CreateRequest { Target = entity }, cancellationToken);
+            LogToConsole("created", TraceEventType.Verbose);
+        }
+        catch (Exception e)
+        {
+            LogToConsole($"create failed {entity.LogicalName}: {e.RootMessage()}", TraceEventType.Error);
+            return false;
+        }
         return true;
     }
 

--- a/src/modules/dgt.power.import/Logic/OutlookTemplateImport.cs
+++ b/src/modules/dgt.power.import/Logic/OutlookTemplateImport.cs
@@ -11,7 +11,10 @@ using dgt.power.import.Base;
 using Microsoft.Crm.Sdk;
 using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Extensions.Configuration;
+using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Query;
 using Spectre.Console;
 using SavedQuery = dgt.power.dataverse.SavedQuery;
 
@@ -27,15 +30,16 @@ public sealed class OutlookTemplateImport(
 {
     private readonly int _sleepTime = configuration.GetValue<int>("pollrate");
 
-    protected override Task<bool> InvokeAsync(ImportVerb args, CancellationToken cancellationToken) =>
-        Task.FromResult(InvokeCore(args));
-
-    private bool InvokeCore(ImportVerb args)
+    protected override Task<bool> InvokeAsync(ImportVerb args, CancellationToken cancellationToken)
     {
-        Debug.Assert(args != null, nameof(args) + " != null");
+        ArgumentNullException.ThrowIfNull(args);
+        return InvokeCoreAsync(args, cancellationToken);
+    }
+
+    private async Task<bool> InvokeCoreAsync(ImportVerb args, CancellationToken cancellationToken)
+    {
         Tracer.Start(this);
         var fileName = string.IsNullOrWhiteSpace(args.FileName) ? "outlooktemplate.json" : args.FileName;
-
 
         if (!ConfigResolver.TryGetConfigFile<dto.SavedQuery>(args.FileDir, fileName, out var queries))
         {
@@ -43,35 +47,46 @@ public sealed class OutlookTemplateImport(
         }
 
         var result = true;
+        var orgAsync = (IOrganizationServiceAsync2)Connection;
 
-        using var context = new DataContext(Connection);
-        var savedQueries = (from sq in context.SavedQuerySet
-            where sq.QueryType == SavedQueryQueryType.OutlookTemplate
-            orderby sq.Name
-            select sq).ToList();
+        var savedQueryExpression = new QueryExpression(SavedQuery.EntityLogicalName)
+        {
+            ColumnSet = new ColumnSet(
+                SavedQuery.LogicalNames.Name,
+                SavedQuery.LogicalNames.IsDefault,
+                SavedQuery.LogicalNames.FetchXml)
+        };
+        savedQueryExpression.Criteria.AddCondition(
+            SavedQuery.LogicalNames.QueryType,
+            ConditionOperator.Equal,
+            SavedQueryQueryType.OutlookTemplate);
+        savedQueryExpression.AddOrder(SavedQuery.LogicalNames.Name, OrderType.Ascending);
+        var retrieveResponse = (RetrieveMultipleResponse)await orgAsync.ExecuteAsync(
+            new RetrieveMultipleRequest { Query = savedQueryExpression },
+            cancellationToken);
+        var savedQueries = retrieveResponse.EntityCollection.Entities.Cast<SavedQuery>().ToList();
 
         foreach (var savedQuery in savedQueries)
         {
             if (queries.DisabledOutlookTemplates.Contains(savedQuery.Name!) && savedQuery.IsDefault == true)
             {
                 Tracer.Log($"Deactivate OutlookTemplate {savedQuery.Name}", TraceEventType.Information);
-                result = Connection.TryUpdate(new SavedQuery(savedQuery.Id)
+                result = await orgAsync.TryUpdateAsync(new SavedQuery(savedQuery.Id)
                 {
                     IsDefault = false
-                }) && result;
+                }, cancellationToken) && result;
             }
 
             if (!queries.DisabledOutlookTemplates.Contains(savedQuery.Name!) && savedQuery.IsDefault == false)
             {
                 Tracer.Log($"Activate OutlookTemplate {savedQuery.Name}", TraceEventType.Information);
-                result = Connection.TryUpdate(new SavedQuery(savedQuery.Id)
+                result = await orgAsync.TryUpdateAsync(new SavedQuery(savedQuery.Id)
                 {
                     IsDefault = true
-                }) && result;
+                }, cancellationToken) && result;
             }
         }
 
-        //anything to do?
         if (queries.OutlookTemplates.Count == 0)
         {
             return Tracer.End(this, result);
@@ -79,20 +94,24 @@ public sealed class OutlookTemplateImport(
 
         foreach (var outlookTemplate in queries.OutlookTemplates)
         {
-            result = UpsertOutlookTemplate(savedQueries, outlookTemplate) && result;
+            result = await UpsertOutlookTemplateAsync(orgAsync, savedQueries, outlookTemplate, cancellationToken) && result;
         }
 
         return Tracer.End(this, result);
     }
 
-    private bool UpsertOutlookTemplate(List<SavedQuery> savedQueries, OutlookTemplate outlookTemplate)
+    private async Task<bool> UpsertOutlookTemplateAsync(
+        IOrganizationServiceAsync2 orgAsync,
+        List<SavedQuery> savedQueries,
+        OutlookTemplate outlookTemplate,
+        CancellationToken cancellationToken)
     {
         var result = true;
         var savedQuery = savedQueries.Find(e => e.Name == outlookTemplate.Name);
         if (savedQuery == null)
         {
             Tracer.Log($"Create OutlookTemplate {outlookTemplate.Name}", TraceEventType.Information);
-            result = Connection.TryCreate(new SavedQuery
+            result = await orgAsync.TryCreateAsync(new SavedQuery
             {
                 FetchXml = outlookTemplate.FetchXml,
                 IsQuickFindQuery = false,
@@ -101,26 +120,26 @@ public sealed class OutlookTemplateImport(
                 ReturnedTypeCode = outlookTemplate.Entity,
                 Name = outlookTemplate.Name,
                 Description = $"{outlookTemplate.Description} ({DateTime.UtcNow:yyyy-MM-dd HH:mm:ss})"
-            }, out _);
+            }, cancellationToken);
         }
         else
         {
-            var current = VerifyFetchXml(savedQuery.FetchXml!);
-            var update = VerifyFetchXml(outlookTemplate.FetchXml);
+            var current = await VerifyFetchXmlAsync(orgAsync, savedQuery.FetchXml!, cancellationToken);
+            var update = await VerifyFetchXmlAsync(orgAsync, outlookTemplate.FetchXml, cancellationToken);
 
             if (!XmlCompare(XElement.Parse(current), XElement.Parse(update)))
             {
                 Tracer.Log($"Update OutlookTemplate {savedQuery.Name}", TraceEventType.Information);
                 Tracer.Log("Update OutlookTemplate does not affect existing rule for users!",
                     TraceEventType.Warning);
-                result = Connection.TryUpdate(new SavedQuery(savedQuery.Id)
+                result = await orgAsync.TryUpdateAsync(new SavedQuery(savedQuery.Id)
                 {
                     IsDefault = false
-                }) && result;
-                Thread.Sleep(_sleepTime);
-                result = Connection.TryDelete(SavedQuery.EntityLogicalName, savedQuery.Id) && result;
-                Thread.Sleep(_sleepTime);
-                result = Connection.TryCreate(new SavedQuery
+                }, cancellationToken) && result;
+                await Task.Delay(_sleepTime, cancellationToken);
+                result = await orgAsync.TryDeleteAsync(SavedQuery.EntityLogicalName, savedQuery.Id, cancellationToken) && result;
+                await Task.Delay(_sleepTime, cancellationToken);
+                result = await orgAsync.TryCreateAsync(new SavedQuery
                 {
                     FetchXml = update,
                     IsQuickFindQuery = false,
@@ -129,7 +148,7 @@ public sealed class OutlookTemplateImport(
                     ReturnedTypeCode = outlookTemplate.Entity,
                     Name = outlookTemplate.Name,
                     Description = $"{outlookTemplate.Description} ({DateTime.UtcNow:yyyy-MM-dd HH:mm:ss})"
-                }, out _) && result;
+                }, cancellationToken) && result;
             }
             else
             {
@@ -140,16 +159,14 @@ public sealed class OutlookTemplateImport(
         return result;
     }
 
-    private string VerifyFetchXml(string current)
+    private static async Task<string> VerifyFetchXmlAsync(IOrganizationServiceAsync2 orgAsync, string fetchXml, CancellationToken cancellationToken)
     {
-        var queryResponse = (FetchXmlToQueryExpressionResponse)Connection.Execute(new FetchXmlToQueryExpressionRequest
-        {
-            FetchXml = current
-        });
-        var xmlResponse = (QueryExpressionToFetchXmlResponse)Connection.Execute(new QueryExpressionToFetchXmlRequest
-        {
-            Query = queryResponse.Query
-        });
+        var queryResponse = (FetchXmlToQueryExpressionResponse)await orgAsync.ExecuteAsync(
+            new FetchXmlToQueryExpressionRequest { FetchXml = fetchXml },
+            cancellationToken);
+        var xmlResponse = (QueryExpressionToFetchXmlResponse)await orgAsync.ExecuteAsync(
+            new QueryExpressionToFetchXmlRequest { Query = queryResponse.Query },
+            cancellationToken);
         return xmlResponse.FetchXml;
     }
 

--- a/src/modules/dgt.power.maintenance/Logic/BulkDeleteUtil.cs
+++ b/src/modules/dgt.power.maintenance/Logic/BulkDeleteUtil.cs
@@ -8,7 +8,9 @@ using dgt.power.dataverse;
 using dgt.power.maintenance.Base;
 using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Extensions.Configuration;
+using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Query;
 using Spectre.Console;
 
@@ -24,12 +26,14 @@ public sealed class BulkDeleteUtil(
 {
     private readonly int _sleepTime = configuration.GetValue<int>("pollrate");
 
-    protected override Task<bool> InvokeAsync(MaintenanceVerb args, CancellationToken cancellationToken) =>
-        Task.FromResult(InvokeCore(args));
-
-    private bool InvokeCore(MaintenanceVerb args)
+    protected override Task<bool> InvokeAsync(MaintenanceVerb args, CancellationToken cancellationToken)
     {
-        Debug.Assert(args != null, nameof(args) + " != null");
+        ArgumentNullException.ThrowIfNull(args);
+        return InvokeCoreAsync(args, cancellationToken);
+    }
+
+    private async Task<bool> InvokeCoreAsync(MaintenanceVerb args, CancellationToken cancellationToken)
+    {
         Tracer.Start(this);
 
         if (string.IsNullOrWhiteSpace(args.InlineData))
@@ -37,14 +41,15 @@ public sealed class BulkDeleteUtil(
             return Tracer.Skipped(this);
         }
 
-        if (GetQueryExpression(args.InlineData, out var query))
+        var (success, query) = await GetQueryExpressionAsync(args.InlineData, cancellationToken);
+        if (success)
         {
             Tracer.Log("Retrieved query expression from inlineData", TraceEventType.Information);
 
-            var asyncOperationId = ExecuteBulkDeleteJob(query);
+            var asyncOperationId = await ExecuteBulkDeleteJobAsync(query!, cancellationToken);
             Tracer.Log($"bulk delete job '{asyncOperationId}' started.", TraceEventType.Information);
 
-            if (Wait(asyncOperationId))
+            if (await WaitAsync(asyncOperationId, cancellationToken))
             {
                 Tracer.Log($"bulk delete job '{asyncOperationId}' finished.", TraceEventType.Information);
                 return Tracer.End(this, true);
@@ -54,16 +59,19 @@ public sealed class BulkDeleteUtil(
         return Tracer.End(this, false);
     }
 
-    private bool Wait(Guid asyncOperationId)
+    private async Task<bool> WaitAsync(Guid asyncOperationId, CancellationToken cancellationToken)
     {
+        var orgAsync = (IOrganizationServiceAsync2)Connection;
         AsyncOperation asyncOperation;
         do
         {
-            Thread.Sleep(_sleepTime);
-            asyncOperation = Connection.Retrieve(
-                AsyncOperation.EntityLogicalName,
-                asyncOperationId,
-                new ColumnSet(AsyncOperation.LogicalNames.StatusCode)).ToEntity<AsyncOperation>();
+            await Task.Delay(_sleepTime, cancellationToken);
+            var retrieveResponse = (RetrieveResponse)await orgAsync.ExecuteAsync(new RetrieveRequest
+            {
+                Target = new EntityReference(AsyncOperation.EntityLogicalName, asyncOperationId),
+                ColumnSet = new ColumnSet(AsyncOperation.LogicalNames.StatusCode)
+            }, cancellationToken);
+            asyncOperation = retrieveResponse.Entity.ToEntity<AsyncOperation>();
             Tracer.Log($"bulk delete job '{asyncOperationId}' running...", TraceEventType.Information);
         } while (IsInExecution(asyncOperation));
 
@@ -81,9 +89,10 @@ public sealed class BulkDeleteUtil(
         && asyncOperation.StatusCode.Value != AsyncOperation.Options.StatusCode.Failed
         && asyncOperation.StatusCode.Value != AsyncOperation.Options.StatusCode.Succeeded;
 
-    private Guid ExecuteBulkDeleteJob(QueryExpression query)
+    private async Task<Guid> ExecuteBulkDeleteJobAsync(QueryExpression query, CancellationToken cancellationToken)
     {
-        var response = (BulkDeleteResponse)Connection.Execute(new BulkDeleteRequest
+        var orgAsync = (IOrganizationServiceAsync2)Connection;
+        var response = (BulkDeleteResponse)await orgAsync.ExecuteAsync(new BulkDeleteRequest
         {
             JobName = "Maintenance BulkDelete job",
             QuerySet = new[] { query },
@@ -93,26 +102,25 @@ public sealed class BulkDeleteUtil(
             SendEmailNotification = false,
             ToRecipients = Array.Empty<Guid>(),
             CCRecipients = Array.Empty<Guid>()
-        });
+        }, cancellationToken);
         return response.JobId;
     }
 
-    private bool GetQueryExpression(string fetchXml, out QueryExpression query)
+    private async Task<(bool Success, QueryExpression? Query)> GetQueryExpressionAsync(string fetchXml, CancellationToken cancellationToken)
     {
-        query = null!;
         try
         {
-            var response = (FetchXmlToQueryExpressionResponse)Connection.Execute(new FetchXmlToQueryExpressionRequest
+            var orgAsync = (IOrganizationServiceAsync2)Connection;
+            var response = (FetchXmlToQueryExpressionResponse)await orgAsync.ExecuteAsync(new FetchXmlToQueryExpressionRequest
             {
                 FetchXml = fetchXml
-            });
-            query = response.Query;
-            return true;
+            }, cancellationToken);
+            return (true, response.Query);
         }
         catch (Exception e) when (e is not OutOfMemoryException and not StackOverflowException)
         {
             Tracer.Log($"Invalid fetch-xml: {e.RootMessage()}", TraceEventType.Error);
-            return false;
+            return (false, null);
         }
     }
 }


### PR DESCRIPTION
Closes #78

## Changes

Full async migration of the two classes still using `Thread.Sleep`.

### `BulkDeleteUtil` (maintenance)
- `InvokeCore` → true `async` `InvokeCoreAsync`
- `Wait` → `WaitAsync`: `Thread.Sleep` → `await Task.Delay(_sleepTime, cancellationToken)`
- All `Connection.Execute`/`Connection.Retrieve` → `IOrganizationServiceAsync2.ExecuteAsync`
- `GetQueryExpression(out)` → `GetQueryExpressionAsync` returning `(bool, QueryExpression?)` tuple

### `OutlookTemplateImport` (import)
- `InvokeCore` → true `async` `InvokeCoreAsync`
- LINQ `DataContext` query → `QueryExpression` + `RetrieveMultipleAsync`
- `UpsertOutlookTemplate` → `UpsertOutlookTemplateAsync`: `Thread.Sleep` → `await Task.Delay`
- `VerifyFetchXml` → `VerifyFetchXmlAsync` using `ExecuteAsync`
- `TryUpdate/TryDelete/TryCreate` → new `TryXxxAsync` extensions

### `OrganizationServiceExtensions` (common)
- Added `TryUpdateAsync`, `TryDeleteAsync`, `TryCreateAsync` on `IOrganizationServiceAsync2`
- Follows validation-split pattern (S4457) consistent with the rest of the codebase

The `pollrate` config key remains the duration source — no breaking change.