### PR TITLE
feat(push): migrate plugin steps and Custom API references on assembly version upgrade

### DIFF
--- a/.memory/implementation-assembly-version-upgrade-migration.md
+++ b/.memory/implementation-assembly-version-upgrade-migration.md
@@ -1,0 +1,46 @@
+# Implementation: Assembly Version Upgrade Migration (Issue #91)
+
+## Problem
+
+When a standalone plugin assembly's major/minor version changes (e.g., `1.0.0.0` → `1.1.0.0`), the push command creates a **new** PluginAssembly record with a new GUID. This left references orphaned:
+
+- **Plugin Steps** (SdkMessageProcessingStep) pointed to old PluginType GUIDs → lost on delete
+- **Custom API** references pointed to old PluginType GUIDs → broken on delete
+
+## Design Decisions
+
+### Two Assemblies = Two Records (Correct)
+In Dataverse, `Name + Version` defines assembly identity. A different major/minor version IS a different assembly. We keep the "create new record" semantics — this is correct and matches Dataverse platform behavior.
+
+### Migration Strategy
+The fix adds **reference migration** — updating FK pointers from old types to new types (matched by `TypeName`) before deletion:
+
+| Scenario | Steps | Custom APIs | Old Assembly |
+|----------|-------|-------------|--------------|
+| Default | Stay on old assembly | Migrated to new | Remains |
+| `--delete-on-upgrade` | Migrated to new | Migrated to new | Deleted |
+| `--no-migrate-custom-apis` | Stay on old | Stay on old | Remains |
+
+### PowerPlugin vs Non-PowerPlugin Distinction
+- **PowerPlugins** (attribute-decorated): Steps are re-created from code attributes (source-of-truth is code). Custom APIs are linked via `CustomApiRegistrationAttribute` in `CreatePluginType()`.
+- **Non-PowerPlugins** (manually configured): Steps MUST be migrated because there's no code source to re-create them. Custom APIs are migrated by TypeName matching.
+
+### Packages Don't Need Changes
+Plugin Packages (.nupkg) are platform-managed: Dataverse preserves assembly GUIDs when package content is updated. All PluginType and Step references survive automatically.
+
+## Implementation
+
+### New Methods in `AssemblyProcessor.cs`
+- `MigratePluginSteps(outdatedAssemblies, newAssembly)` — Updates `SdkMessageProcessingStep.EventHandler` to point to matching new PluginType
+- `MigrateCustomApis(outdatedAssemblies, newAssembly)` — Updates `CustomAPI.PluginTypeId` to point to matching new PluginType
+
+### Migration Algorithm
+Types are matched between old and new assembly by **fully qualified TypeName** (e.g., `MyNamespace.MyPlugin`). If a type was removed in the new version, a warning is logged and its references are left for the subsequent delete to clean up.
+
+### New CLI Flag
+`--no-migrate-custom-apis` — Opt-out from default Custom API migration (ignored when `--delete-on-upgrade` forces it).
+
+## Edge Cases
+- Type renamed between versions → no match → warning logged → old references lost on delete
+- Type removed in new version → no migration target → warning logged
+- `--delete-on-upgrade` + `--no-migrate-custom-apis` → Custom API migration forced anyway (deletion would break references)

--- a/.memory/summary.md
+++ b/.memory/summary.md
@@ -111,5 +111,6 @@ The TypeScript/Liquid (TSL) template engine has enterprise-grade hardening:
 | `implementation-centralized-ci-environment-detection.md` | implementation | ExecutionEnvironment in common; reused by telemetry + codegen |
 | `implementation-tsl-p1-p2-completion.md` | implementation | TSL hardening: diagnostics, options factory, compile gates, test suites |
 | `implementation-registration-attributes.md` | implementation | Push module: all evaluated registration attributes, behavior, and limitations |
+| `implementation-assembly-version-upgrade-migration.md` | implementation | Push module: migrate Steps/CustomAPIs on assembly major/minor version upgrade |
 | `research-servicepointmanager-dotnet8.md` | research | ServicePointManager no-op; Dataverse.Client has no HttpClient hook |
 | `research-tsl-fluid-hardening.md` | research | Fluid.Core stability assessment and hardening strategy |

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Pushes a plugin assembly or web resource into a target solution.
 
 ```bash
 dgtp push ./bin/Release/MyPlugin.dll --solution mysolution
+dgtp push ./bin/Release/MyPlugin.1.0.0.nupkg --solution mysolution
 ```
 
 #### Supported Registration Attributes
@@ -268,6 +269,18 @@ When a plugin assembly is decorated with `ManagedIdentityRegistrationAttribute` 
 3. Links the `PluginAssembly.ManagedIdentityId` to the managed identity record
 
 This enables plugins to use Azure Managed Identity for secure service-to-service authentication without manual registration steps.
+
+#### Assembly Version Upgrade
+
+When a plugin assembly's **major or minor** version changes (e.g. `1.0.0.0` → `1.1.0.0`), the push command creates a **new** assembly record in Dataverse (since a different version constitutes a different assembly identity). The tool handles reference migration:
+
+| Flag | Behavior |
+|------|----------|
+| *(default)* | New assembly is created; Custom API references are migrated to new types automatically |
+| `--delete-on-upgrade` | Migrates **plugin steps** and Custom APIs to the new assembly, then deletes the old assembly |
+| `--no-migrate-custom-apis` | Skips Custom API migration (ignored when `--delete-on-upgrade` is set, since deletion requires migration) |
+
+> **Plugin Packages (.nupkg):** No special handling needed — the platform manages assembly GUIDs within a package. Content updates preserve all references automatically.
 
 ## 🏗 Solution Architecture
 

--- a/src/modules/dgt.power.push/Base/PushVerb.cs
+++ b/src/modules/dgt.power.push/Base/PushVerb.cs
@@ -31,8 +31,12 @@ public class PushVerb : BaseProgramSettings
     public bool Publish { get; set; }
 
     [CommandOption("--delete-on-upgrade")]
-    [Description("Delete old pluginsteps on Upgrade of PluginAssembly")]
+    [Description("Delete old assembly on Upgrade; migrates plugin steps and Custom API references to new assembly before deletion")]
     public bool DeleteOnUpgrade { get; set; }
+
+    [CommandOption("--no-migrate-custom-apis")]
+    [Description("Do not migrate Custom API references to new assembly on Upgrade (ignored when --delete-on-upgrade is set)")]
+    public bool NoMigrateCustomApis { get; set; }
 
     [CommandOption("--config")]
     [Description("Configuration file for webressources mapping")]

--- a/src/modules/dgt.power.push/Logic/AssemblyProcessor.cs
+++ b/src/modules/dgt.power.push/Logic/AssemblyProcessor.cs
@@ -242,7 +242,7 @@ internal sealed class AssemblyProcessor : IDisposable
             foreach (var oldType in oldAssembly.PluginTypes)
             {
                 var newType = newAssembly.PluginTypes
-                    .SingleOrDefault(t => t.TypeName == oldType.TypeName);
+                    .FirstOrDefault(t => t.TypeName == oldType.TypeName);
 
                 if (newType == null)
                 {
@@ -278,7 +278,7 @@ internal sealed class AssemblyProcessor : IDisposable
             foreach (var oldType in oldAssembly.PluginTypes)
             {
                 var newType = newAssembly.PluginTypes
-                    .SingleOrDefault(t => t.TypeName == oldType.TypeName);
+                    .FirstOrDefault(t => t.TypeName == oldType.TypeName);
 
                 if (newType == null)
                 {

--- a/src/modules/dgt.power.push/Logic/AssemblyProcessor.cs
+++ b/src/modules/dgt.power.push/Logic/AssemblyProcessor.cs
@@ -230,6 +230,95 @@ internal sealed class AssemblyProcessor : IDisposable
         _service.Delete(PluginAssembly.EntityLogicalName, assemblyId);
     }
 
+    /// <summary>
+    /// Migrates plugin steps from old assembly types to new assembly types (matched by TypeName).
+    /// Used during upgrade with --delete-on-upgrade for non-PowerPlugin assemblies to preserve
+    /// manually registered steps that would otherwise be lost when the old assembly is deleted.
+    /// </summary>
+    public void MigratePluginSteps(IReadOnlyList<AssemblyContent> outdatedAssemblies, Assembly newAssembly)
+    {
+        foreach (var oldAssembly in outdatedAssemblies)
+        {
+            foreach (var oldType in oldAssembly.PluginTypes)
+            {
+                var newType = newAssembly.PluginTypes
+                    .SingleOrDefault(t => t.TypeName == oldType.TypeName);
+
+                if (newType == null)
+                {
+                    _console.MarkupLine(CultureInfo.InvariantCulture,
+                        " [yellow]Type [bold]{0}[/] removed in new version - steps will be deleted[/]",
+                        oldType.TypeName);
+                    continue;
+                }
+
+                foreach (var step in oldType.PluginSteps)
+                {
+                    _console.MarkupLine(CultureInfo.InvariantCulture,
+                        " Migrate Step [green]{0}[/] from Type [bold]{1}[/] ({2:D}) to ({3:D})",
+                        step.Name, oldType.TypeName, oldType.Id, newType.Id);
+                    _service.Update(new SdkMessageProcessingStep(step.Id)
+                    {
+                        EventHandler = new EntityReference(
+                            dataverse.PluginType.EntityLogicalName, newType.Id)
+                    });
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Migrates Custom API references from old assembly types to new assembly types (matched by TypeName).
+    /// By default, Custom APIs should point to the latest assembly version so they execute the newest code.
+    /// </summary>
+    public void MigrateCustomApis(IReadOnlyList<AssemblyContent> outdatedAssemblies, Assembly newAssembly)
+    {
+        foreach (var oldAssembly in outdatedAssemblies)
+        {
+            foreach (var oldType in oldAssembly.PluginTypes)
+            {
+                var newType = newAssembly.PluginTypes
+                    .SingleOrDefault(t => t.TypeName == oldType.TypeName);
+
+                if (newType == null)
+                {
+                    _console.MarkupLine(CultureInfo.InvariantCulture,
+                        " [yellow]Type [bold]{0}[/] removed in new version - Custom API references cannot be migrated[/]",
+                        oldType.TypeName);
+                    continue;
+                }
+
+                var query = new QueryExpression
+                {
+                    EntityName = CustomAPI.EntityLogicalName,
+                    ColumnSet = new ColumnSet(CustomAPI.LogicalNames.UniqueName, CustomAPI.LogicalNames.PluginTypeId),
+                    NoLock = true,
+                    Criteria = new FilterExpression(LogicalOperator.And)
+                    {
+                        Conditions =
+                        {
+                            new ConditionExpression(CustomAPI.LogicalNames.PluginTypeId,
+                                ConditionOperator.Equal, oldType.Id)
+                        }
+                    }
+                };
+
+                var apis = _service.RetrieveMultiple(query).Entities.Select(e => e.ToEntity<CustomAPI>()).ToList();
+                foreach (var api in apis)
+                {
+                    _console.MarkupLine(CultureInfo.InvariantCulture,
+                        " Migrate Custom API [green]{0}[/] from Type [bold]{1}[/] ({2:D}) to ({3:D})",
+                        api.UniqueName, oldType.TypeName, oldType.Id, newType.Id);
+                    _service.Update(new CustomAPI(api.Id)
+                    {
+                        PluginTypeId = new EntityReference(
+                            dataverse.PluginType.EntityLogicalName, newType.Id)
+                    });
+                }
+            }
+        }
+    }
+
     private void AddPluginAssemblyToSolution(PluginAssembly pluginAssembly, string solution)
     {
         // PluginAssembly = 91

--- a/src/modules/dgt.power.push/Logic/AssemblyProcessor.cs
+++ b/src/modules/dgt.power.push/Logic/AssemblyProcessor.cs
@@ -242,7 +242,7 @@ internal sealed class AssemblyProcessor : IDisposable
             foreach (var oldType in oldAssembly.PluginTypes)
             {
                 var newType = newAssembly.PluginTypes
-                    .FirstOrDefault(t => t.TypeName == oldType.TypeName);
+                    .Find(t => t.TypeName == oldType.TypeName);
 
                 if (newType == null)
                 {
@@ -278,7 +278,7 @@ internal sealed class AssemblyProcessor : IDisposable
             foreach (var oldType in oldAssembly.PluginTypes)
             {
                 var newType = newAssembly.PluginTypes
-                    .FirstOrDefault(t => t.TypeName == oldType.TypeName);
+                    .Find(t => t.TypeName == oldType.TypeName);
 
                 if (newType == null)
                 {
@@ -308,7 +308,7 @@ internal sealed class AssemblyProcessor : IDisposable
                 {
                     _console.MarkupLine(CultureInfo.InvariantCulture,
                         " Migrate Custom API [green]{0}[/] from Type [bold]{1}[/] ({2:D}) to ({3:D})",
-                        api.UniqueName, oldType.TypeName, oldType.Id, newType.Id);
+                        api.UniqueName ?? string.Empty, oldType.TypeName, oldType.Id, newType.Id);
                     _service.Update(new CustomAPI(api.Id)
                     {
                         PluginTypeId = new EntityReference(

--- a/src/modules/dgt.power.push/PushCommand.cs
+++ b/src/modules/dgt.power.push/PushCommand.cs
@@ -184,8 +184,31 @@ public class PushCommand : Command<PushVerb>, IPowerLogic
 
             if (settings.DeleteOnUpgrade  && state == AssemblyState.Upgrade && localAssembly.Type.HasFlag(AssemblyType.Plugin))
             {
-                ctx.Status("Purge outdated plugin types");
+                ctx.Status("Build outdated assembly references");
                 var outdated = modelBuilder.BuildOutdatedAssemblyContentFromCrm(localAssembly.Name);
+
+                // Migrate steps to new assembly before deleting old one (non-PowerPlugin only,
+                // PowerPlugins re-create steps from attributes above)
+                if (!localAssembly.Type.HasFlag(AssemblyType.PowerPlugin) && outdated.Count > 0)
+                {
+                    ctx.Status("Migrate plugin steps to new assembly");
+                    _console.MarkupLine(CultureInfo.InvariantCulture,
+                        "Migrate plugin steps from outdated assemblies to [bold green]{0} ({1})[/]",
+                        localAssembly.Name, localAssembly.Version);
+                    processor.MigratePluginSteps(outdated, crmAssembly);
+                }
+
+                // Custom APIs must always be migrated when deleting old assembly (regardless of --no-migrate-custom-apis)
+                if (!localAssembly.Type.HasFlag(AssemblyType.PowerPlugin) && outdated.Count > 0)
+                {
+                    ctx.Status("Migrate Custom API references to new assembly");
+                    _console.MarkupLine(CultureInfo.InvariantCulture,
+                        "Migrate Custom API references from outdated assemblies to [bold green]{0} ({1})[/]",
+                        localAssembly.Name, localAssembly.Version);
+                    processor.MigrateCustomApis(outdated, crmAssembly);
+                }
+
+                ctx.Status("Purge outdated plugin types");
                 foreach (var assemblyContent in outdated)
                 {
                     foreach (var pluginType in assemblyContent.PluginTypes)
@@ -194,6 +217,21 @@ public class PushCommand : Command<PushVerb>, IPowerLogic
                     }
 
                     processor.DeletePluginAssembly(assemblyContent.Id);
+                }
+            }
+            else if (!settings.NoMigrateCustomApis && state == AssemblyState.Upgrade && localAssembly.Type.HasFlag(AssemblyType.Plugin)
+                     && !localAssembly.Type.HasFlag(AssemblyType.PowerPlugin))
+            {
+                // Migrate Custom APIs by default on Upgrade (even without --delete-on-upgrade)
+                // PowerPlugins handle Custom API linking via CreatePluginType already
+                ctx.Status("Migrate Custom API references to new assembly");
+                var outdated = modelBuilder.BuildOutdatedAssemblyContentFromCrm(localAssembly.Name);
+                if (outdated.Count > 0)
+                {
+                    _console.MarkupLine(CultureInfo.InvariantCulture,
+                        "Migrate Custom API references from outdated assemblies to [bold green]{0} ({1})[/]",
+                        localAssembly.Name, localAssembly.Version);
+                    processor.MigrateCustomApis(outdated, crmAssembly);
                 }
             }
         }

--- a/src/modules/dgt.power.push/PushCommand.cs
+++ b/src/modules/dgt.power.push/PushCommand.cs
@@ -198,8 +198,10 @@ public class PushCommand : Command<PushVerb>, IPowerLogic
                     processor.MigratePluginSteps(outdated, crmAssembly);
                 }
 
-                // Custom APIs must always be migrated when deleting old assembly (regardless of --no-migrate-custom-apis)
-                if (!localAssembly.Type.HasFlag(AssemblyType.PowerPlugin) && outdated.Count > 0)
+                // Custom APIs must always be migrated when deleting old assembly to prevent broken references.
+                // This applies to ALL assembly types including PowerPlugins (covers manually linked Custom APIs
+                // that aren't handled by the attribute-based CreatePluginType linking).
+                if (outdated.Count > 0)
                 {
                     ctx.Status("Migrate Custom API references to new assembly");
                     _console.MarkupLine(CultureInfo.InvariantCulture,

--- a/tests/dgt.power.push.tests/Logic/AssemblyProcessorMigrationTests.cs
+++ b/tests/dgt.power.push.tests/Logic/AssemblyProcessorMigrationTests.cs
@@ -22,7 +22,7 @@ public class AssemblyProcessorMigrationTests
     public void Setup()
     {
         _service = new FakeOrganizationServiceAsync();
-        _service.AddRequests([new AddSolutionComponentExecutor()]);
+        _service.AddRequests(new AddSolutionComponentExecutor());
         _service.AddDefaultRequests();
         _console = new TestConsole();
         _processor = new AssemblyProcessor(_service, _console);
@@ -32,6 +32,7 @@ public class AssemblyProcessorMigrationTests
     public void Teardown()
     {
         _processor.Dispose();
+        _console.Dispose();
     }
 
     #region MigratePluginSteps
@@ -353,9 +354,8 @@ public class AssemblyProcessorMigrationTests
             PluginTypes = { new PluginType { Name = "NoApi", TypeName = "MyNamespace.NoApi", FriendlyName = "NoApi", Id = newTypeId } }
         };
 
-        // Act & Assert - should not throw
+        // Act - should not throw
         _processor.MigrateCustomApis(outdatedAssemblies, newAssembly);
-        await Assert.That(true).IsTrue();
     }
 
     #endregion

--- a/tests/dgt.power.push.tests/Logic/AssemblyProcessorMigrationTests.cs
+++ b/tests/dgt.power.push.tests/Logic/AssemblyProcessorMigrationTests.cs
@@ -1,0 +1,362 @@
+// Copyright (c) DIGITALL Nature. All rights reserved
+// DIGITALL Nature licenses this file to you under the Microsoft Public License.
+
+using dgt.power.dataverse;
+using dgt.power.push.Logic;
+using dgt.power.push.Model;
+using dgt.power.tests.FakeExecutor;
+using Digitall.Dataverse.Testing;
+using Microsoft.Xrm.Sdk;
+using Spectre.Console.Testing;
+using PluginType = dgt.power.push.Model.PluginType;
+
+namespace dgt.power.push.tests.Logic;
+
+public class AssemblyProcessorMigrationTests
+{
+    private FakeOrganizationServiceAsync _service = null!;
+    private AssemblyProcessor _processor = null!;
+    private TestConsole _console = null!;
+
+    [Before(Test)]
+    public void Setup()
+    {
+        _service = new FakeOrganizationServiceAsync();
+        _service.AddRequests([new AddSolutionComponentExecutor()]);
+        _service.AddDefaultRequests();
+        _console = new TestConsole();
+        _processor = new AssemblyProcessor(_service, _console);
+    }
+
+    [After(Test)]
+    public void Teardown()
+    {
+        _processor.Dispose();
+    }
+
+    #region MigratePluginSteps
+
+    [Test]
+    public async Task MigratePluginSteps_MatchingTypes_ShouldUpdateStepEventHandler()
+    {
+        // Arrange
+        var oldTypeId = Guid.NewGuid();
+        var newTypeId = Guid.NewGuid();
+        var stepId = Guid.NewGuid();
+        var messageId = Guid.NewGuid();
+
+        var step = new SdkMessageProcessingStep
+        {
+            Id = stepId,
+            EventHandler = new EntityReference(dataverse.PluginType.EntityLogicalName, oldTypeId),
+            Name = "TestStep",
+            SdkMessageId = new EntityReference(SdkMessage.EntityLogicalName, messageId)
+        };
+        _service.AddRange([step]);
+
+        var outdatedAssemblies = new List<AssemblyContent>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                PluginTypes =
+                {
+                    new PluginType
+                    {
+                        Name = "MyPlugin",
+                        TypeName = "MyNamespace.MyPlugin",
+                        FriendlyName = "MyPlugin",
+                        Id = oldTypeId,
+                        PluginSteps = { new PluginStep { Id = stepId, Name = "TestStep" } }
+                    }
+                }
+            }
+        };
+
+        var newAssembly = new Assembly
+        {
+            Name = "TestAssembly",
+            Version = "1.1.0.0",
+            Id = Guid.NewGuid(),
+            PluginTypes = { new PluginType { Name = "MyPlugin", TypeName = "MyNamespace.MyPlugin", FriendlyName = "MyPlugin", Id = newTypeId } }
+        };
+
+        // Act
+        _processor.MigratePluginSteps(outdatedAssemblies, newAssembly);
+
+        // Assert
+        var updatedStep = _service.Retrieve(SdkMessageProcessingStep.EntityLogicalName, stepId,
+            new Microsoft.Xrm.Sdk.Query.ColumnSet(true)).ToEntity<SdkMessageProcessingStep>();
+        await Assert.That(updatedStep.EventHandler!.Id).IsEqualTo(newTypeId);
+    }
+
+    [Test]
+    public async Task MigratePluginSteps_TypeRemovedInNewVersion_ShouldSkipAndLogWarning()
+    {
+        // Arrange
+        var oldTypeId = Guid.NewGuid();
+        var stepId = Guid.NewGuid();
+
+        var step = new SdkMessageProcessingStep
+        {
+            Id = stepId,
+            EventHandler = new EntityReference(dataverse.PluginType.EntityLogicalName, oldTypeId),
+            Name = "TestStep"
+        };
+        _service.AddRange([step]);
+
+        var outdatedAssemblies = new List<AssemblyContent>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                PluginTypes =
+                {
+                    new PluginType
+                    {
+                        Name = "RemovedPlugin",
+                        TypeName = "MyNamespace.RemovedPlugin",
+                        FriendlyName = "RemovedPlugin",
+                        Id = oldTypeId,
+                        PluginSteps = { new PluginStep { Id = stepId, Name = "TestStep" } }
+                    }
+                }
+            }
+        };
+
+        // New assembly does NOT contain "RemovedPlugin"
+        var newAssembly = new Assembly
+        {
+            Name = "TestAssembly",
+            Version = "1.1.0.0",
+            Id = Guid.NewGuid(),
+            PluginTypes = { new PluginType { Name = "OtherPlugin", TypeName = "MyNamespace.OtherPlugin", FriendlyName = "OtherPlugin", Id = Guid.NewGuid() } }
+        };
+
+        // Act
+        _processor.MigratePluginSteps(outdatedAssemblies, newAssembly);
+
+        // Assert - step should NOT be updated (still points to old type)
+        var unchangedStep = _service.Retrieve(SdkMessageProcessingStep.EntityLogicalName, stepId,
+            new Microsoft.Xrm.Sdk.Query.ColumnSet(true)).ToEntity<SdkMessageProcessingStep>();
+        await Assert.That(unchangedStep.EventHandler!.Id).IsEqualTo(oldTypeId);
+
+        // Warning should be logged
+        var output = _console.Output;
+        await Assert.That(output).Contains("removed in new version");
+    }
+
+    [Test]
+    public async Task MigratePluginSteps_MultipleStepsOnSameType_ShouldMigrateAll()
+    {
+        // Arrange
+        var oldTypeId = Guid.NewGuid();
+        var newTypeId = Guid.NewGuid();
+        var stepId1 = Guid.NewGuid();
+        var stepId2 = Guid.NewGuid();
+
+        _service.AddRange([
+            new SdkMessageProcessingStep { Id = stepId1, EventHandler = new EntityReference(dataverse.PluginType.EntityLogicalName, oldTypeId), Name = "Step1" },
+            new SdkMessageProcessingStep { Id = stepId2, EventHandler = new EntityReference(dataverse.PluginType.EntityLogicalName, oldTypeId), Name = "Step2" }
+        ]);
+
+        var outdatedAssemblies = new List<AssemblyContent>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                PluginTypes =
+                {
+                    new PluginType
+                    {
+                        Name = "MyPlugin", TypeName = "MyNamespace.MyPlugin", FriendlyName = "MyPlugin", Id = oldTypeId,
+                        PluginSteps =
+                        {
+                            new PluginStep { Id = stepId1, Name = "Step1" },
+                            new PluginStep { Id = stepId2, Name = "Step2" }
+                        }
+                    }
+                }
+            }
+        };
+
+        var newAssembly = new Assembly
+        {
+            Name = "TestAssembly", Version = "1.1.0.0", Id = Guid.NewGuid(),
+            PluginTypes = { new PluginType { Name = "MyPlugin", TypeName = "MyNamespace.MyPlugin", FriendlyName = "MyPlugin", Id = newTypeId } }
+        };
+
+        // Act
+        _processor.MigratePluginSteps(outdatedAssemblies, newAssembly);
+
+        // Assert
+        var s1 = _service.Retrieve(SdkMessageProcessingStep.EntityLogicalName, stepId1, new Microsoft.Xrm.Sdk.Query.ColumnSet(true)).ToEntity<SdkMessageProcessingStep>();
+        var s2 = _service.Retrieve(SdkMessageProcessingStep.EntityLogicalName, stepId2, new Microsoft.Xrm.Sdk.Query.ColumnSet(true)).ToEntity<SdkMessageProcessingStep>();
+        await Assert.That(s1.EventHandler!.Id).IsEqualTo(newTypeId);
+        await Assert.That(s2.EventHandler!.Id).IsEqualTo(newTypeId);
+    }
+
+    #endregion
+
+    #region MigrateCustomApis
+
+    [Test]
+    public async Task MigrateCustomApis_MatchingTypes_ShouldUpdateApiPluginTypeId()
+    {
+        // Arrange
+        var oldTypeId = Guid.NewGuid();
+        var newTypeId = Guid.NewGuid();
+        var apiId = Guid.NewGuid();
+
+        var customApi = new CustomAPI
+        {
+            Id = apiId,
+            UniqueName = "my_custom_action",
+            PluginTypeId = new EntityReference(dataverse.PluginType.EntityLogicalName, oldTypeId)
+        };
+        _service.AddRange([customApi]);
+
+        var outdatedAssemblies = new List<AssemblyContent>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                PluginTypes =
+                {
+                    new PluginType
+                    {
+                        Name = "ActionPlugin", TypeName = "MyNamespace.ActionPlugin", FriendlyName = "ActionPlugin", Id = oldTypeId
+                    }
+                }
+            }
+        };
+
+        var newAssembly = new Assembly
+        {
+            Name = "TestAssembly", Version = "1.1.0.0", Id = Guid.NewGuid(),
+            PluginTypes = { new PluginType { Name = "ActionPlugin", TypeName = "MyNamespace.ActionPlugin", FriendlyName = "ActionPlugin", Id = newTypeId } }
+        };
+
+        // Act
+        _processor.MigrateCustomApis(outdatedAssemblies, newAssembly);
+
+        // Assert
+        var updatedApi = _service.Retrieve(CustomAPI.EntityLogicalName, apiId,
+            new Microsoft.Xrm.Sdk.Query.ColumnSet(true)).ToEntity<CustomAPI>();
+        await Assert.That(updatedApi.PluginTypeId!.Id).IsEqualTo(newTypeId);
+    }
+
+    [Test]
+    public async Task MigrateCustomApis_TypeRemovedInNewVersion_ShouldSkipAndLogWarning()
+    {
+        // Arrange
+        var oldTypeId = Guid.NewGuid();
+        var apiId = Guid.NewGuid();
+
+        var customApi = new CustomAPI
+        {
+            Id = apiId,
+            UniqueName = "my_action",
+            PluginTypeId = new EntityReference(dataverse.PluginType.EntityLogicalName, oldTypeId)
+        };
+        _service.AddRange([customApi]);
+
+        var outdatedAssemblies = new List<AssemblyContent>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                PluginTypes =
+                {
+                    new PluginType { Name = "Removed", TypeName = "MyNamespace.Removed", FriendlyName = "Removed", Id = oldTypeId }
+                }
+            }
+        };
+
+        var newAssembly = new Assembly
+        {
+            Name = "TestAssembly", Version = "1.1.0.0", Id = Guid.NewGuid(),
+            PluginTypes = { new PluginType { Name = "Other", TypeName = "MyNamespace.Other", FriendlyName = "Other", Id = Guid.NewGuid() } }
+        };
+
+        // Act
+        _processor.MigrateCustomApis(outdatedAssemblies, newAssembly);
+
+        // Assert - API should NOT be updated
+        var unchangedApi = _service.Retrieve(CustomAPI.EntityLogicalName, apiId,
+            new Microsoft.Xrm.Sdk.Query.ColumnSet(true)).ToEntity<CustomAPI>();
+        await Assert.That(unchangedApi.PluginTypeId!.Id).IsEqualTo(oldTypeId);
+
+        // Warning logged
+        var output = _console.Output;
+        await Assert.That(output).Contains("cannot be migrated").Or.Contains("removed in new version");
+    }
+
+    [Test]
+    public async Task MigrateCustomApis_MultipleApisOnSameType_ShouldMigrateAll()
+    {
+        // Arrange
+        var oldTypeId = Guid.NewGuid();
+        var newTypeId = Guid.NewGuid();
+        var apiId1 = Guid.NewGuid();
+        var apiId2 = Guid.NewGuid();
+
+        _service.AddRange([
+            new CustomAPI { Id = apiId1, UniqueName = "action_one", PluginTypeId = new EntityReference(dataverse.PluginType.EntityLogicalName, oldTypeId) },
+            new CustomAPI { Id = apiId2, UniqueName = "action_two", PluginTypeId = new EntityReference(dataverse.PluginType.EntityLogicalName, oldTypeId) }
+        ]);
+
+        var outdatedAssemblies = new List<AssemblyContent>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                PluginTypes = { new PluginType { Name = "MultiApi", TypeName = "MyNamespace.MultiApi", FriendlyName = "MultiApi", Id = oldTypeId } }
+            }
+        };
+
+        var newAssembly = new Assembly
+        {
+            Name = "TestAssembly", Version = "1.1.0.0", Id = Guid.NewGuid(),
+            PluginTypes = { new PluginType { Name = "MultiApi", TypeName = "MyNamespace.MultiApi", FriendlyName = "MultiApi", Id = newTypeId } }
+        };
+
+        // Act
+        _processor.MigrateCustomApis(outdatedAssemblies, newAssembly);
+
+        // Assert
+        var a1 = _service.Retrieve(CustomAPI.EntityLogicalName, apiId1, new Microsoft.Xrm.Sdk.Query.ColumnSet(true)).ToEntity<CustomAPI>();
+        var a2 = _service.Retrieve(CustomAPI.EntityLogicalName, apiId2, new Microsoft.Xrm.Sdk.Query.ColumnSet(true)).ToEntity<CustomAPI>();
+        await Assert.That(a1.PluginTypeId!.Id).IsEqualTo(newTypeId);
+        await Assert.That(a2.PluginTypeId!.Id).IsEqualTo(newTypeId);
+    }
+
+    [Test]
+    public async Task MigrateCustomApis_NoApisLinked_ShouldNotThrow()
+    {
+        // Arrange
+        var oldTypeId = Guid.NewGuid();
+        var newTypeId = Guid.NewGuid();
+
+        var outdatedAssemblies = new List<AssemblyContent>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                PluginTypes = { new PluginType { Name = "NoApi", TypeName = "MyNamespace.NoApi", FriendlyName = "NoApi", Id = oldTypeId } }
+            }
+        };
+
+        var newAssembly = new Assembly
+        {
+            Name = "TestAssembly", Version = "1.1.0.0", Id = Guid.NewGuid(),
+            PluginTypes = { new PluginType { Name = "NoApi", TypeName = "MyNamespace.NoApi", FriendlyName = "NoApi", Id = newTypeId } }
+        };
+
+        // Act & Assert - should not throw
+        _processor.MigrateCustomApis(outdatedAssemblies, newAssembly);
+        await Assert.That(true).IsTrue();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Resolves #91 — Plugin assemblies with major/minor version changes now properly migrate references during push.

## Problem

When pushing a plugin assembly with a higher major/minor version (e.g. `1.0.0.0` → `1.1.0.0`), the tool correctly creates a **new** PluginAssembly record (different version = different identity in Dataverse). However, when using `--delete-on-upgrade` to clean up the old assembly, manually registered **plugin steps** and **Custom API references** were permanently lost — they were deleted with the old types without being migrated to the new assembly.

## Design Decisions

### 1. Two Versions = Two Assemblies (unchanged)
In .NET/Dataverse, `Name + Version` defines assembly identity. A major/minor bump IS a different assembly. We keep the existing "create new record" behavior — this is semantically correct and matches how Dataverse works.

### 2. Plugin Step Migration: Only with `--delete-on-upgrade`
- **Without** the flag: Both assemblies coexist, old steps still work on old assembly → no migration needed
- **With** the flag: Old assembly will be deleted → steps MUST be migrated to prevent data loss
- Only for **non-PowerPlugin** assemblies (PowerPlugins re-create steps from code attributes — that IS the source of truth)

### 3. Custom API Migration: Default ON
- When you push a new version, you want Custom APIs to execute the new code immediately
- Default: Custom APIs are migrated to new types (matched by `TypeName`)
- New flag `--no-migrate-custom-apis` to opt out (for staged rollouts)
- Ignored when `--delete-on-upgrade` is set (deletion would break references anyway)

### 4. Packages: No Changes Needed
Plugin Packages (.nupkg) are platform-managed — Dataverse preserves assembly GUIDs internally when package content is updated. All PluginType and Step references survive automatically.

## Migration Algorithm

Types between old and new assembly are matched by **fully qualified TypeName** (e.g. `MyNamespace.MyPlugin`):

```
Old Assembly v1.0.0.0                  New Assembly v1.1.0.0
├── PluginType "Ns.Foo" (GUID A)      ├── PluginType "Ns.Foo" (GUID B)   ← matched!
│   ├── Step: Create Account    ──────────► UPDATE EventHandler → B
│   └── CustomApi: my_action    ──────────► UPDATE PluginTypeId → B
└── PluginType "Ns.Removed"           └── (not present = no match → warning)
```

## Flag Matrix

| Scenario | Custom APIs | Steps | Old Assembly |
|----------|-------------|-------|--------------|
| Default (no flags) | ✅ Migrated | ❌ Stay on old | Remains |
| `--delete-on-upgrade` | ✅ Migrated | ✅ Migrated | Deleted |
| `--no-migrate-custom-apis` | ❌ Not migrated | ❌ | Remains |
| `--delete-on-upgrade --no-migrate-custom-apis` | ✅ Forced (deletion requires it) | ✅ Migrated | Deleted |

## Changes

| File | Change |
|------|--------|
| `PushVerb.cs` | Added `--no-migrate-custom-apis` flag, improved `--delete-on-upgrade` description |
| `AssemblyProcessor.cs` | Added `MigratePluginSteps()` and `MigrateCustomApis()` methods |
| `PushCommand.cs` | Integrated migration logic into upgrade flow (before delete) |
| `dgt.power.push.csproj` | Added `InternalsVisibleTo` for test access |
| `AssemblyProcessorMigrationTests.cs` | 7 new unit tests covering migration scenarios |
| `README.md` | Documented assembly upgrade behavior and flags |

## Tests

All 16 push tests pass (7 new + 9 existing). New tests cover:
- Step migration with matching types
- Step migration when type is removed in new version (warning logged)
- Multiple steps on same type
- Custom API migration with matching types
- Custom API migration when type removed (warning logged)
- Multiple Custom APIs on same type
- No APIs linked (no-op, no error)

## Open Questions for Review

1. Should we add a `--migrate-steps` flag (independent of `--delete-on-upgrade`) for users who want step migration without deleting the old assembly?
2. Should we log a summary count (e.g. "Migrated 5 steps, 2 Custom APIs") at the end?
3. The contributor comment mentions Custom API — should we verify that `CustomApiRequestParameter` and `CustomApiResponseProperty` records follow the `CustomAPI.PluginTypeId` reference automatically, or do they need separate migration?