### PR TITLE
feat(push): evaluate CustomDataProviderRegistrationAttribute for step generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,17 @@ Pushes a plugin assembly or web resource into a target solution.
 dgtp push ./bin/Release/MyPlugin.dll --solution mysolution
 ```
 
+#### Supported Registration Attributes
+
+When pushing a plugin assembly, `push` evaluates the following attributes from the `dgt.registration` package:
+
+| Attribute | Purpose |
+|-----------|---------|
+| `PluginRegistrationAttribute` | Registers plugin steps (message, stage, mode, entity filters, images) |
+| `CustomApiRegistrationAttribute` | Links a plugin type to a Custom API by message name |
+| `CustomDataProviderRegistrationAttribute` | Generates data provider steps (Retrieve, RetrieveMultiple, Create, Update, Delete) for virtual entities |
+| `WorkflowRegistrationAttribute` | Marks workflow activities with group/name metadata |
+
 ## 🏗 Solution Architecture
 
 DigitallPower is built as a modular CLI. The host project (`dgt.power`) wires up dependency injection (`Microsoft.Extensions.DependencyInjection`), configuration (`Microsoft.Extensions.Configuration`) and the [Spectre.Console.Cli](https://spectreconsole.net/cli/) command framework, and then registers commands contributed by independent feature modules.

--- a/src/modules/dgt.power.push/Logic/AssemblyModelBuilder.cs
+++ b/src/modules/dgt.power.push/Logic/AssemblyModelBuilder.cs
@@ -349,6 +349,11 @@ internal sealed class AssemblyModelBuilder : IDisposable
                     {
                         type.CustomApi = GetValue<string>(customAttribute, "messageName")!;
                     }
+
+                    if (customAttribute.AttributeType.Name == nameof(CustomDataProviderRegistrationAttribute))
+                    {
+                        type.PluginSteps.AddRange(GetDataProviderPluginSteps(pluginType, customAttribute));
+                    }
                 }
 
                 type.PluginSteps.AddRange(GetRegistrationPluginSteps(pluginType));
@@ -589,6 +594,62 @@ internal sealed class AssemblyModelBuilder : IDisposable
     #endregion
 
     #region dgt.registration
+
+    /// <summary>
+    /// Generates plugin steps from a CustomDataProviderRegistrationAttribute.
+    /// Data providers run at Stage 30 (MainOperation), Synchronous mode, on the virtual entity.
+    /// </summary>
+    private List<PluginStep> GetDataProviderPluginSteps(Type pluginType, CustomAttributeData customAttribute)
+    {
+        var steps = new List<PluginStep>();
+
+        var entityName = GetValue<string>(customAttribute, "entityName")!;
+        var eventValue = GetValue<int>(customAttribute, "eventRegistration");
+        var messageName = MapDataProviderEventToMessage(eventValue);
+
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
+        var sdk = (from mf in _context.SdkMessageFilterSet
+            join m in _context.SdkMessageSet on mf.SdkMessageId.Id equals m.Id
+            where mf.PrimaryObjectTypeCode == entityName
+            where m.Name == messageName
+            select new { mf, m }).SingleOrDefault();
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
+
+        if (sdk?.m == null || sdk.mf == null)
+        {
+            _console.MarkupLine(CultureInfo.InvariantCulture,
+                "[yellow]Warning: DataProvider message {0} for entity {1} not found - skipping step[/]",
+                messageName, entityName);
+            return steps;
+        }
+
+        var step = new PluginStep
+        {
+            Mode = SdkMessageProcessingStep.Options.Mode.Synchronous,
+            MessageName = messageName,
+            Stage = SdkMessageProcessingStep.Options.Stage.MainOperationForInternalUseOnly,
+            PrimaryEntityName = entityName,
+            SecondaryEntityName = "none",
+            ExecutionOrder = 1,
+            ParentName = pluginType.FullName!,
+            MessageId = sdk.m.SdkMessageId!.Value,
+            MessageFilterId = sdk.mf.SdkMessageFilterId!.Value
+        };
+        step.Name = GetStepName(step);
+        steps.Add(step);
+
+        return steps;
+    }
+
+    internal static string MapDataProviderEventToMessage(int eventValue) => eventValue switch
+    {
+        0 => "Retrieve",
+        1 => "RetrieveMultiple",
+        2 => "Create",
+        3 => "Update",
+        4 => "Delete",
+        _ => throw new AssemblyException($"Unknown DataProviderEvent value: {eventValue}")
+    };
 
     private List<PluginStep> GetRegistrationPluginSteps(Type pluginType)
     {

--- a/src/modules/dgt.power.push/dgt.power.push.csproj
+++ b/src/modules/dgt.power.push/dgt.power.push.csproj
@@ -10,6 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>
+        dgt.power.push.tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dd58806217d8819acb3b578e6db06a61f7622022a88ce2d405b94b26a78b191880b92719a99150cc55536f52e929eb02c26c18ccb06ff92f06987471a8cd37a8ba58996497f983028d582836e28a7c7aa04909baca865c7546d7dd9a78938cb1212bd122e60d90a1a851f79960dfb094bf709373072721b0bad7e31f76d52fd0</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="dgt.registration" Version="1.0.1" />
     <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.8" />

--- a/tests/dgt.power.push.tests/Logic/DataProviderRegistrationTests.cs
+++ b/tests/dgt.power.push.tests/Logic/DataProviderRegistrationTests.cs
@@ -1,0 +1,33 @@
+// Copyright (c) DIGITALL Nature. All rights reserved
+// DIGITALL Nature licenses this file to you under the Microsoft Public License.
+
+using dgt.power.push.Logic;
+using dgt.power.push.Model;
+
+namespace dgt.power.push.tests.Logic;
+
+public class DataProviderRegistrationTests
+{
+    [Test]
+    [Arguments(0, "Retrieve")]
+    [Arguments(1, "RetrieveMultiple")]
+    [Arguments(2, "Create")]
+    [Arguments(3, "Update")]
+    [Arguments(4, "Delete")]
+    public async Task MapDataProviderEventToMessage_ReturnsCorrectMessage(int eventValue, string expectedMessage)
+    {
+        // Act
+        var result = AssemblyModelBuilder.MapDataProviderEventToMessage(eventValue);
+
+        // Assert
+        await Assert.That(result).IsEqualTo(expectedMessage);
+    }
+
+    [Test]
+    public async Task MapDataProviderEventToMessage_ThrowsForUnknownEvent()
+    {
+        // Act & Assert
+        await Assert.That(() => AssemblyModelBuilder.MapDataProviderEventToMessage(99))
+            .ThrowsExactly<AssemblyException>();
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for generating plugin steps from `CustomDataProviderRegistrationAttribute` during push.

### Problem

When a plugin type is decorated with `CustomDataProviderRegistrationAttribute` (from `dgt.registration`), the push module previously only recognized it as a PowerPlugin but did **not** generate the necessary `SdkMessageProcessingStep` records. This meant data provider plugins for virtual entities had to be manually registered.

### Solution

In `AssemblyModelBuilder.ParseAssembly()`, the attribute is now evaluated to extract:
- `EntityName` — the virtual entity's logical name
- `Event` — the `DataProviderEvent` enum (Retrieve, RetrieveMultiple, Create, Update, Delete)

A plugin step is generated with:
- **Stage:** 30 (MainOperation) — required for data providers
- **Mode:** Synchronous — required for data providers
- **PrimaryEntity:** the virtual entity name
- **Message:** mapped from the enum value

### Design Decisions

1. **AllowMultiple support:** The attribute supports `AllowMultiple = true`, and our implementation handles multiple attributes per type correctly.
2. **Graceful degradation:** If the SDK message/filter combination is not found in the target environment, a warning is printed and the step is skipped.
3. **Mapping is explicit:** A switch expression maps enum values to message names, throwing for unknown values to catch attribute version mismatches early.

### Testing

- 6 unit tests covering all event-to-message mappings and the error case
- All 15 push module tests pass

### Changes

- `src/modules/dgt.power.push/Logic/AssemblyModelBuilder.cs` — Added `GetDataProviderPluginSteps()` and `MapDataProviderEventToMessage()`
- `src/modules/dgt.power.push/dgt.power.push.csproj` — Added `InternalsVisibleTo` for test access
- `tests/dgt.power.push.tests/Logic/DataProviderRegistrationTests.cs` — New test file
- `README.md` — Documented supported registration attributes

Closes #91 (partial)