### PR TITLE
perf(push): skip redundant AddSolutionComponent calls — load solution contents once

### DIFF
--- a/.memory/guide-webresource-solution-lazy-add.md
+++ b/.memory/guide-webresource-solution-lazy-add.md
@@ -1,0 +1,45 @@
+# Guide: Webresource Solution Membership — Lazy Add Pattern
+
+## Problem
+
+When pushing webresources with `--solution`, the original code called `AddSolutionComponent` for
+**every** resource (Create, Update, and Up2Date states) on every push, even if the resource was
+already part of the solution. This caused:
+
+- Unnecessary API calls to Dataverse on each push run
+- Higher risk of transient failures due to redundant `AddSolutionComponent` calls
+- `DiscoverObsoleteWebresources` made a second separate DB query (JOIN) that was identical in scope
+  to the upfront load needed for membership checks
+
+## Solution
+
+Solution contents (unmanaged webresources in the target solution) are loaded **once** at the start
+of `Process()` via `LoadSolutionContents(solutionId)` — only when `--solution` is set — and passed
+to both `UpsertResources` and `DiscoverObsoleteWebresources`.
+
+### Key model
+
+`SolutionWebresourceInfo` (`Model/SolutionWebresourceInfo.cs`) is a `record` carrying:
+- `WebResourceId` (Guid) — primary key of the webresource
+- `WebResourceType` (int) — OptionSetValue.Value for type comparison
+- `Name` (string) — logical name used for obsolescence check
+
+### Add guard logic
+
+`IsAlreadyInSolution(Guid, IReadOnlyCollection<SolutionWebresourceInfo>?)` static helper.
+
+| State | Behaviour |
+|-------|-----------|
+| Create | Always call `AddSolutionComponent` (new resource, not yet in solution) |
+| Update | Only call `AddSolutionComponent` if NOT in `solutionContents` |
+| Up2Date | Only call `AddSolutionComponent` if NOT in `solutionContents` |
+
+### Obsolete resource discovery
+
+`DiscoverObsoleteWebresources` previously re-queried `WebResourceSet JOIN SolutionComponentSet`.
+After this change it iterates the pre-loaded `solutionContents` directly — no second round trip.
+
+## Load condition
+
+`LoadSolutionContents` is called when `solutionId.HasValue`, which is true whenever `--solution`
+is specified. Both `--solution` and `--delete-obsolete` therefore share the same pre-fetched data.

--- a/.memory/summary.md
+++ b/.memory/summary.md
@@ -134,5 +134,6 @@ The TypeScript/Liquid (TSL) template engine has enterprise-grade hardening:
 | `implementation-tsl-p1-p2-completion.md` | implementation | TSL hardening: diagnostics, options factory, compile gates, test suites |
 | `implementation-registration-attributes.md` | implementation | Push module: all evaluated registration attributes, behavior, and limitations |
 | `implementation-assembly-version-upgrade-migration.md` | implementation | Push module: migrate Steps/CustomAPIs on assembly major/minor version upgrade |
+| `guide-webresource-solution-lazy-add.md` | guide | Push module: only add webresource to solution when not already a member; single pre-fetch for both upsert + obsolete checks |
 | `research-servicepointmanager-dotnet8.md` | research | ServicePointManager no-op; Dataverse.Client has no HttpClient hook |
 | `research-tsl-fluid-hardening.md` | research | Fluid.Core stability assessment and hardening strategy |

--- a/src/modules/dgt.power.push/Logic/WebresourcesProcessor.cs
+++ b/src/modules/dgt.power.push/Logic/WebresourcesProcessor.cs
@@ -61,16 +61,23 @@ public class WebresourcesProcessor(
             throw new ArgumentException("Delete Obsolete without proper solution set - aborting");
         }
 
+        SolutionWebresourceInfo[]? solutionContents = null;
+        if (solutionId.HasValue)
+        {
+            statusCallback?.Invoke("Load solution contents");
+            solutionContents = LoadSolutionContents(solutionId.Value);
+        }
+
         statusCallback?.Invoke("Discover webresources");
         var localWebresources = DiscoverWebresources(settings.Target, prefix, fileMappings);
 
         statusCallback?.Invoke("Upsert webresources");
-        UpsertResources(localWebresources, solutionId, settings.Solution, settings.Publish);
+        UpsertResources(localWebresources, solutionId, settings.Solution, settings.Publish, solutionContents);
 
         if (settings.DeleteObsolete)
         {
             statusCallback?.Invoke("Discover obsolete webresources");
-            var obsoleteWebresources = DiscoverObsoleteWebresources(solutionId!.Value, localWebresources);
+            var obsoleteWebresources = DiscoverObsoleteWebresources(localWebresources, solutionContents!);
 
             statusCallback?.Invoke("Delete webresources");
             DeleteResources(obsoleteWebresources);
@@ -85,6 +92,16 @@ public class WebresourcesProcessor(
         }
 
         return ("new", null);
+    }
+
+    private SolutionWebresourceInfo[] LoadSolutionContents(Guid solutionId)
+    {
+        return (from wr in _context.WebResourceSet
+            join sc in _context.SolutionComponentSet on wr.WebResourceId equals sc.ObjectId
+            where sc.SolutionId!.Id == solutionId
+            where wr.IsManaged == false
+            select new SolutionWebresourceInfo(wr.WebResourceId!.Value, wr.WebResourceType!.Value, wr.Name!))
+            .ToArray();
     }
 
     private (string prefix, Guid solutionId) LoadSolution(string solutionUniqueName)
@@ -142,7 +159,7 @@ public class WebresourcesProcessor(
         resource.XrmId = existing.Id;
     }
 
-    private void UpsertResources(Webresources[] webresources, Guid? solutionId, string? solutionName, bool publish)
+    private void UpsertResources(Webresources[] webresources, Guid? solutionId, string? solutionName, bool publish, IReadOnlyCollection<SolutionWebresourceInfo>? solutionContents)
     {
         foreach (var resource in webresources.Where(f => f.State == WebresourceState.Create))
         {
@@ -173,7 +190,7 @@ public class WebresourcesProcessor(
                 Description = $"Upserted with DGTP: {resource.Hash}"
             });
 
-            if (solutionId.HasValue)
+            if (solutionId.HasValue && !IsAlreadyInSolution(resource.XrmId!.Value, solutionContents))
             {
                 AddResourceToSolution(resource.XrmId!.Value, resource.Name, solutionName!);
             }
@@ -192,10 +209,16 @@ public class WebresourcesProcessor(
         {
             foreach (var resource in webresources.Where(f => f.State == WebresourceState.Up2Date))
             {
-                AddResourceToSolution(resource.XrmId!.Value, resource.Name, solutionName!);
+                if (!IsAlreadyInSolution(resource.XrmId!.Value, solutionContents))
+                {
+                    AddResourceToSolution(resource.XrmId!.Value, resource.Name, solutionName!);
+                }
             }
         }
     }
+
+    private static bool IsAlreadyInSolution(Guid resourceId, IReadOnlyCollection<SolutionWebresourceInfo>? solutionContents)
+        => solutionContents?.Any(s => s.WebResourceId == resourceId) ?? false;
 
     private void AddResourceToSolution(Guid resourceId, string resourceName, string solutionName)
     {
@@ -221,20 +244,14 @@ public class WebresourcesProcessor(
         }
     }
 
-    private IEnumerable<Webresources> DiscoverObsoleteWebresources(Guid solutionId, Webresources[] webresources)
+    private IEnumerable<Webresources> DiscoverObsoleteWebresources(Webresources[] webresources, IReadOnlyCollection<SolutionWebresourceInfo> solutionContents)
     {
-        var webresourcesInSolution = from wr in _context.WebResourceSet
-            join sc in _context.SolutionComponentSet on wr.WebResourceId equals sc.ObjectId
-            where sc.SolutionId!.Id == solutionId
-            where wr.IsManaged == false
-            select new { wr.WebResourceId, wr.WebResourceType, wr.Name };
-
-        foreach (var webresource in webresourcesInSolution)
+        foreach (var webresource in solutionContents)
         {
-            if (webresources.SingleOrDefault(f => f.Type == webresource.WebResourceType.Value && f.Name == webresource.Name) == null)
+            if (webresources.SingleOrDefault(f => f.Type == webresource.WebResourceType && f.Name == webresource.Name) == null)
             {
                 console.MarkupLine(CultureInfo.InvariantCulture, "Found obsolete: [Green]{0}[/] <{1}>", webresource.Name, webresource.WebResourceType);
-                yield return new Webresources(webresource.WebResourceType.Value, webresource.Name, WebresourceState.Delete, webresource.WebResourceId!.Value);
+                yield return new Webresources(webresource.WebResourceType, webresource.Name, WebresourceState.Delete, webresource.WebResourceId);
             }
         }
     }

--- a/src/modules/dgt.power.push/Model/SolutionWebresourceInfo.cs
+++ b/src/modules/dgt.power.push/Model/SolutionWebresourceInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) DIGITALL Nature. All rights reserved
+// DIGITALL Nature licenses this file to you under the Microsoft Public License.
+
+namespace dgt.power.push.Model;
+
+internal record SolutionWebresourceInfo(Guid WebResourceId, int WebResourceType, string Name);

--- a/tests/dgt.power.push.tests/Logic/WebresourcesProcessorTests.cs
+++ b/tests/dgt.power.push.tests/Logic/WebresourcesProcessorTests.cs
@@ -183,4 +183,94 @@ public class WebresourcesProcessorTests : PushTestsBase<PushCommand>
         await Assert.That(result).IsTrue();
         await Assert.That(addedComponents).IsEmpty();
     }
+
+    [Test]
+    public async Task ShouldNotAddWebresourceToSolution_WhenAlreadyInSolutionAndUnchanged()
+    {
+        // Arrange — resource is Up2Date in CRM and already in solution
+        var addedComponents = new List<AddSolutionComponentRequest>();
+        var (publisher, solution) = CreateSolutionData();
+        var existingWebResourceId = Guid.NewGuid();
+        var existingWebResource = new WebResource(existingWebResourceId)
+        {
+            Name = WebresourceLogicalName,
+            WebResourceType = new OptionSetValue((int)WebResource.Options.WebResourceType.ScriptJScript),
+            Content = KnownJsBase64
+        };
+        existingWebResource.Attributes[WebResource.LogicalNames.IsManaged] = false;
+
+        var solutionComponent = new SolutionComponent(Guid.NewGuid());
+        solutionComponent.Attributes[SolutionComponent.LogicalNames.ObjectId] = existingWebResourceId;
+        solutionComponent.Attributes[SolutionComponent.LogicalNames.SolutionId] =
+            new EntityReference(Solution.EntityLogicalName, solution.Id);
+
+        var ctx = GetBuilder()
+            .WithServiceCollection(new TestServiceCollection().AddScoped<WebresourcesProcessor>())
+            .WithExecutionMock<AddSolutionComponentRequest>(req =>
+            {
+                addedComponents.Add((AddSolutionComponentRequest)req);
+                return new AddSolutionComponentResponse();
+            })
+            .WithData(publisher)
+            .WithData(solution)
+            .WithData(existingWebResource)
+            .WithData(solutionComponent)
+            .Build();
+
+        // Act
+        var result = ctx.Execute(new PushVerb
+        {
+            Target = WebresourcesFolder,
+            Solution = SolutionUniqueName
+        });
+
+        // Assert
+        await Assert.That(result).IsTrue();
+        await Assert.That(addedComponents).IsEmpty();
+    }
+
+    [Test]
+    public async Task ShouldNotAddWebresourceToSolution_WhenAlreadyInSolutionAndUpdated()
+    {
+        // Arrange — resource has stale content in CRM (needs update) but is already in solution
+        var addedComponents = new List<AddSolutionComponentRequest>();
+        var (publisher, solution) = CreateSolutionData();
+        var existingWebResourceId = Guid.NewGuid();
+        var existingWebResource = new WebResource(existingWebResourceId)
+        {
+            Name = WebresourceLogicalName,
+            WebResourceType = new OptionSetValue((int)WebResource.Options.WebResourceType.ScriptJScript),
+            Content = Convert.ToBase64String("old content"u8.ToArray())
+        };
+        existingWebResource.Attributes[WebResource.LogicalNames.IsManaged] = false;
+
+        var solutionComponent = new SolutionComponent(Guid.NewGuid());
+        solutionComponent.Attributes[SolutionComponent.LogicalNames.ObjectId] = existingWebResourceId;
+        solutionComponent.Attributes[SolutionComponent.LogicalNames.SolutionId] =
+            new EntityReference(Solution.EntityLogicalName, solution.Id);
+
+        var ctx = GetBuilder()
+            .WithServiceCollection(new TestServiceCollection().AddScoped<WebresourcesProcessor>())
+            .WithExecutionMock<AddSolutionComponentRequest>(req =>
+            {
+                addedComponents.Add((AddSolutionComponentRequest)req);
+                return new AddSolutionComponentResponse();
+            })
+            .WithData(publisher)
+            .WithData(solution)
+            .WithData(existingWebResource)
+            .WithData(solutionComponent)
+            .Build();
+
+        // Act
+        var result = ctx.Execute(new PushVerb
+        {
+            Target = WebresourcesFolder,
+            Solution = SolutionUniqueName
+        });
+
+        // Assert
+        await Assert.That(result).IsTrue();
+        await Assert.That(addedComponents).IsEmpty();
+    }
 }


### PR DESCRIPTION
## Problem

When pushing webresources with `--solution`, `AddSolutionComponent` was called for **every** resource (Create, Update, Up2Date) on every push — even if the resource was already a member of the solution. Additionally, `--delete-obsolete` issued a second, independent `WebResourceSet JOIN SolutionComponentSet` query with identical scope.

## Solution

Load the solution's current webresource members **once** upfront via `LoadSolutionContents(solutionId)` (triggered when `--solution` is set). Pass the result to both `UpsertResources` and `DiscoverObsoleteWebresources`.

### Behaviour changes

| State | Before | After |
|-------|--------|-------|
| Create | Always add | Always add (new resource, not yet in solution) |
| Update | Always add | Add only if **not** already in solution |
| Up2Date | Always add | Add only if **not** already in solution |
| `--delete-obsolete` | Second JOIN query | Uses pre-loaded collection — no extra round-trip |

### New model
`SolutionWebresourceInfo` — internal record carrying `WebResourceId`, `WebResourceType`, `Name` for membership checks.

### Tests added
- `ShouldNotAddWebresourceToSolution_WhenAlreadyInSolutionAndUnchanged`
- `ShouldNotAddWebresourceToSolution_WhenAlreadyInSolutionAndUpdated`