### PR TITLE
feat(telemetry): harden error anonymization and record exceptions as OTel events

### DIFF
--- a/.memory/decision-error-telemetry-anonymization.md
+++ b/.memory/decision-error-telemetry-anonymization.md
@@ -1,0 +1,46 @@
+# Decision: Error Telemetry and Anonymization
+
+## Context
+
+To improve the reliability of the DigitallPower CLI, we need to collect crash data and exception details. However, since the tool is used in enterprise environments, we must ensure that no personally identifiable information (PII) or sensitive environment data (like Dataverse organization URLs or user paths) is transmitted.
+
+## Decision
+
+We will implement automated error telemetry that captures exceptions from three main entry points:
+1. **Spectre.Console Exception Handler:** Captures all exceptions thrown during command execution.
+2. **AppDomain.CurrentDomain.UnhandledException:** Captures fatal crashes that happen outside of the command lifecycle (e.g., during startup).
+3. **TaskScheduler.UnobservedTaskException:** Captures exceptions from leaked tasks.
+
+### Anonymization Strategy
+
+To protect user privacy, all captured error data must be anonymized before transmission:
+
+1. **GUIDs:** All GUIDs (including Dataverse record IDs, solution IDs, etc.) are replaced with a zero-GUID (`00000000-0000-0000-0000-000000000000`).
+2. **Local home-directory paths:** Absolute paths under a recognizable home-directory root (`/Users/<name>/...`, `/home/<name>/...`, `/root/...`, `C:\Users\<name>\...`) are shortened to just the file name (e.g. `/Users/jdoe/Source/dgtp/src/dgt.power/Program.cs` becomes `Program.cs`). This applies to both exception **messages** and **stack traces** — messages of exceptions like `DirectoryNotFoundException` or `FileNotFoundException` frequently embed the full local path and, with it, the OS username.
+3. **Stack trace frames:** Every `at ... in <path>:line N` frame additionally has its path shortened to the file name regardless of which root it lives under (build-machine paths without a home directory still reveal folder layout, even if they don't carry a username).
+4. **Dataverse organization URLs:** Any `https://<org>[.api][.crmN].dynamics.com/...` URL is replaced with the fixed placeholder `[dataverse-org-url-redacted]` — Dataverse SDK exceptions routinely embed the org URL, which directly identifies the customer and is at least as sensitive as a record GUID.
+5. **Entra ID tenant URLs:** Any `https://<tenant>.onmicrosoft.com/...` URL is replaced with `[entra-tenant-url-redacted]` for the same reason.
+6. **Exception messages:** GUID, path, and URL anonymization above is applied uniformly to `error.Message`.
+
+**Known scope limitations (accepted trade-offs):**
+- Only paths under a recognized home-directory root are stripped from *messages* (not every conceivable absolute path) — this avoids false positives that would otherwise mangle unrelated text such as generic URLs (`/tmp/`, `/var/`, arbitrary API paths were deliberately excluded from the message-level regex; see `TelemetryAnonymizerTests.Anonymize_WithUnrelatedUrl_LeavesUrlUntouched`).
+- Freeform PII embedded directly in a message without a recognizable path/URL shape (e.g. `"User jdoe attempted ..."`, email addresses) is **not** detected. Anonymization here is regex-based and best-effort, not a guarantee.
+
+## Implementation Details
+
+- **`TelemetryAnonymizer`:** Static internal class in `dgt.power.Telemetry`. `Anonymize(string)` handles GUIDs, org/tenant URLs, and home-directory paths for single-line text (exception messages); `AnonymizeStackTrace(string)` additionally shortens every stack frame's path and then delegates to `Anonymize` for the rest. Line splitting uses a regex (`\r\n|\r|\n`) rather than `Environment.NewLine`, so a stack trace captured with different line endings than the current OS (e.g. crossing a serialization boundary) is still processed frame-by-frame instead of being treated as one giant unsplit line.
+- **`ITracer.TrackFatalException`:** Added to the tracer interface to allow logging exceptions that occur outside of a specific `IPowerLogic` activity.
+- **Exception recording as OTel events:** Both `Tracer.Exception` and `Tracer.TrackFatalException` record the anonymized exception as a standard OpenTelemetry **exception event** (`ActivityEvent("exception", tags: {exception.type, exception.message, exception.stacktrace, exception.escaped})`) on top of setting them as span tags. The Azure Monitor exporter only projects exception *events* — not plain span tags — into the Application Insights `exceptions` table / Failures blade, so this is required for crashes to show up as first-class exception telemetry rather than only as custom dimensions on a `dependency` row.
+- **`Program.cs` Integration:** The global handlers are registered as early as possible after the tracer is initialized.
+
+## Alternatives Considered
+
+- **Transmitting full stack traces:** Rejected due to privacy concerns regarding local user names in paths.
+- **Transmitting full messages without anonymization:** Rejected because Dataverse error messages often contain specific record GUIDs.
+- **Removing messages entirely:** Rejected because it would make debugging significantly harder. The anonymization strike a balance between privacy and utility.
+
+## Consequences
+
+- Improved ability to identify and fix recurring crashes.
+- Transparent documentation in README.md about what is collected.
+- Small performance overhead for regex replacement during crashes (acceptable since the app is terminating anyway).

--- a/.memory/summary.md
+++ b/.memory/summary.md
@@ -70,6 +70,7 @@ src/
 | Post-TSL architecture priorities | `decision-post-tsl-architecture-wave.md` | VSTHRD200/002, S1067/S3358, debt-baseline for S1135/S125 |
 | Remove sync Invoke from PowerLogic | `decision-remove-sync-invoke.md` | InvokeAsync is now the single abstract entry point; Task.FromResult interim pattern |
 | Non-interactive auth for coding agents | `decision-non-interactive-auth-for-agents.md` | `--non-interactive`/`DGTP_NON_INTERACTIVE`, exit code 2, `dgtp profile auth-check` command |
+| Error telemetry anonymization | `decision-error-telemetry-anonymization.md` | Automated crash reporting recorded as OTel exception events; GUID/home-path/org-URL redaction for privacy |
 
 ## TSL Template Engine (codegeneration)
 
@@ -169,3 +170,4 @@ The TypeScript/Liquid (TSL) template engine has enterprise-grade hardening:
 | `research-v2-typescript-config-design-gaps.md` | research | Current V2 TS caveats after redesign: no `TypingPath`, no per-entity filters, string-based `forms.filter` |
 | `implementation-v2-codegeneration-config-shape.md` | implementation | Final nested V2 config shape: shared `entities` scope, `optionSets`, and target-specific `output` blocks |
 | `implementation-v2-schema-allows-dollar-schema.md` | implementation | V2 schemas now allow top-level `$schema` for editor compatibility under `additionalProperties: false` |
+| `decision-error-telemetry-anonymization.md` | decision | Crash reporting via OTel exception events; anonymization scope (GUIDs, home-dir paths, org/tenant URLs) and known limitations |

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ dgtp complete setup
 dgtp complete install-shell
 ```
 
-This auto-detects your current shell and writes the shim to your RC file.  
-Use `--shell bash|zsh|pwsh|fish` to override the detected shell.  
+This auto-detects your current shell and writes the shim to your RC file.
+Use `--shell bash|zsh|pwsh|fish` to override the detected shell.
 Use `--dry-run` to preview what would be written without making changes.
 
 The shim is written with idempotency markers — running the command again does nothing if already installed:
@@ -645,8 +645,18 @@ DigitallPower collects anonymous usage telemetry to help improve the tool. Telem
 | OS platform | `Unix` | Platform distribution |
 | Tool version | `2.1.0` | Version adoption |
 | Anonymous install ID | `a1b2c3d4-...` | Count unique installations |
+| Crash data | `ExceptionType`, `anonymized stacktrace` | Improve reliability by identifying common crashes |
 
-**No personally identifiable information is collected.** No usernames, organization URLs, file contents, or environment-specific data is ever transmitted.
+**No personally identifiable information is collected.** Error messages and stack traces are automatically anonymized before being sent — the following data is stripped or replaced with fixed placeholders:
+
+| Found in error data | Replaced with |
+|---|---|
+| GUIDs (record IDs, solution IDs, ...) | `00000000-0000-0000-0000-000000000000` |
+| Local home-directory paths (`/Users/<name>/...`, `/home/<name>/...`, `C:\Users\<name>\...`) | just the file name, e.g. `Program.cs` |
+| Dataverse organization URLs (`https://contoso.crm4.dynamics.com/...`) | `[dataverse-org-url-redacted]` |
+| Entra ID tenant URLs (`https://contoso.onmicrosoft.com/...`) | `[entra-tenant-url-redacted]` |
+
+This anonymization is implemented in `TelemetryAnonymizer` and covered by unit tests for both Unix and Windows path formats. It is a best-effort, regex-based approach — see `.memory/decision-error-telemetry-anonymization.md` for its exact scope and known limitations.
 
 CI detection is centralized in `dgt.power.common.ExecutionEnvironment` and currently recognizes `TF_BUILD`, `BUILD_BUILDURI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `JENKINS_URL`, and `CI`.
 
@@ -688,6 +698,39 @@ dependencies
 | summarize CI = countif(is_ci), NonCI = countif(not(is_ci)) by module
 | order by CI + NonCI desc
 ```
+
+### Retrieving crash/error data in Application Insights
+
+Every exception (whether it terminates a command, or crashes the process entirely) is recorded both as an OpenTelemetry span attribute (for quick filtering alongside command telemetry) **and** as a standard OpenTelemetry exception event, which the Azure Monitor exporter surfaces natively in the **`exceptions`** table / the **Failures** blade of the Application Insights resource.
+
+**To look at it in the Azure Portal:**
+
+1. Open the Application Insights resource associated with the connection string configured via `DGT_TELEMETRY_CONNECTION_STRING` (or the build's embedded default).
+2. Go to **Investigate → Failures** for a quick overview of the most frequent exception types and their trend over time, or
+3. Go to **Monitoring → Logs** and run a KQL query directly, e.g.:
+
+```kusto
+// Most frequent (anonymized) exception types over the last 30 days
+exceptions
+| where timestamp > ago(30d)
+| extend
+    exceptionType = tostring(customDimensions["exception.type"]),
+    version = tostring(customDimensions["dgtp.version"]),
+    isFatal = operation_Name == "fatal_exception"
+| summarize Count = count() by exceptionType, version, isFatal
+| order by Count desc
+```
+
+```kusto
+// Full anonymized message + stack trace for a specific exception type
+exceptions
+| where timestamp > ago(30d)
+| where tostring(customDimensions["exception.type"]) == "System.IO.DirectoryNotFoundException"
+| project timestamp, message = tostring(customDimensions["exception.message"]), stack = tostring(customDimensions["exception.stacktrace"]), version = tostring(customDimensions["dgtp.version"])
+| order by timestamp desc
+```
+
+Since crashes outside of a command's lifecycle (startup failures, unobserved task exceptions) are recorded as their own `fatal_exception` operation rather than under a `command.*` operation, filter on `operation_Name == "fatal_exception"` to isolate those from regular command-scoped exceptions.
 
 ### First-run notice
 

--- a/src/dgt.power.common/ITracer.cs
+++ b/src/dgt.power.common/ITracer.cs
@@ -20,4 +20,6 @@ public interface ITracer
     bool End<T>(T action, bool result) where T : IPowerLogic;
 
     void Exception(Exception e, TraceEventType type);
+
+    void TrackFatalException(Exception e);
 }

--- a/src/dgt.power/Program.cs
+++ b/src/dgt.power/Program.cs
@@ -105,7 +105,25 @@ if (telemetryEnabled)
     }
 }
 
-registrations.AddSingleton<ITracer>(_ => new Tracer(telemetryEnabled, installId, appConsole));
+var tracer = new Tracer(telemetryEnabled, installId, appConsole);
+registrations.AddSingleton<ITracer>(tracer);
+
+AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+{
+    if (e.ExceptionObject is Exception ex)
+    {
+        tracer.TrackFatalException(ex);
+    }
+    tracerProvider?.ForceFlush(5000);
+    tracerProvider?.Dispose();
+};
+
+TaskScheduler.UnobservedTaskException += (_, e) =>
+{
+    tracer.TrackFatalException(e.Exception);
+    e.SetObserved();
+};
+
 registrations.AddSingleton<IConfiguration>(configuration);
 registrations.AddSingleton<IXrmConnection, XrmConnection>();
 registrations.AddSingleton<IProfileManager, ProfileManager>();
@@ -140,6 +158,7 @@ app.Configure(config =>
 
     config.SetExceptionHandler((exception, _) =>
     {
+        tracer.TrackFatalException(exception);
         var inner = exception.IsDerivedFrom<AbstractPowerException>()
             ? exception.GetInnerException<AbstractPowerException>()
             : null;

--- a/src/dgt.power/Telemetry/TelemetryAnonymizer.cs
+++ b/src/dgt.power/Telemetry/TelemetryAnonymizer.cs
@@ -1,0 +1,122 @@
+// Copyright (c) DIGITALL Nature. All rights reserved
+// DIGITALL Nature licenses this file to you under the Microsoft Public License.
+
+using System.Text.RegularExpressions;
+
+namespace dgt.power.Telemetry;
+
+/// <summary>
+/// Strips personally identifiable and environment-specific information from exception messages and
+/// stack traces before they are sent to telemetry. See <c>.memory/decision-error-telemetry-anonymization.md</c>
+/// for the rationale and the scope/limitations of this best-effort anonymization.
+/// </summary>
+internal static partial class TelemetryAnonymizer
+{
+    private const string RedactedGuid = "00000000-0000-0000-0000-000000000000";
+    private const string RedactedOrgUrl = "[dataverse-org-url-redacted]";
+    private const string RedactedTenantUrl = "[entra-tenant-url-redacted]";
+
+    private static readonly Regex GuidRegex = GetGuidRegex();
+    private static readonly Regex DataverseOrgUrlRegex = GetDataverseOrgUrlRegex();
+    private static readonly Regex EntraTenantUrlRegex = GetEntraTenantUrlRegex();
+
+    // Matches well-known "home directory" roots that carry a local username, on any OS:
+    // /Users/<name>/... (macOS), /home/<name>/... (Linux), /root/... (Linux root), C:\Users\<name>\... (Windows).
+    // We deliberately don't try to anonymize *every* absolute path (e.g. /tmp/, /var/, arbitrary URLs) to avoid
+    // mangling unrelated text - only paths that are likely to reveal a real person's username.
+    private static readonly Regex UnixHomePathRegex = GetUnixHomePathRegex();
+    private static readonly Regex WindowsHomePathRegex = GetWindowsHomePathRegex();
+
+    /// <summary>
+    /// Anonymizes a single-line message: GUIDs, Dataverse organization URLs, Entra tenant URLs and
+    /// local home-directory paths are replaced with fixed placeholders.
+    /// </summary>
+    public static string Anonymize(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return string.Empty;
+        }
+
+        var result = GuidRegex.Replace(input, RedactedGuid);
+        result = DataverseOrgUrlRegex.Replace(result, RedactedOrgUrl);
+        result = EntraTenantUrlRegex.Replace(result, RedactedTenantUrl);
+        result = UnixHomePathRegex.Replace(result, m => StripToFileName(m.Value, '/'));
+        result = WindowsHomePathRegex.Replace(result, m => StripToFileName(m.Value, '\\'));
+
+        return result;
+    }
+
+    /// <summary>
+    /// Anonymizes a (potentially multi-line) stack trace. In addition to the generic <see cref="Anonymize"/>
+    /// rules, every "at ... in &lt;path&gt;:line N" frame has its path shortened to just the file name,
+    /// regardless of which root the path lives under (source paths don't necessarily carry a username,
+    /// but they do reveal local folder structure / build machine layout).
+    /// </summary>
+    public static string AnonymizeStackTrace(string? stackTrace)
+    {
+        if (string.IsNullOrEmpty(stackTrace))
+        {
+            return string.Empty;
+        }
+
+        // Split on any line ending (\r\n, \r or \n), not just Environment.NewLine: the stack trace may
+        // originate from a different platform than the one currently anonymizing it (e.g. a serialized
+        // exception, or a dependency that always emits \n regardless of OS).
+        var lines = LineSplitRegex().Split(stackTrace);
+        for (var i = 0; i < lines.Length; i++)
+        {
+            // Example line: "   at dgt.power.Program.<>c.<<Main>$>b__0_1(Exception exception, ITypeResolver _) in /Users/Name/Source/Project/src/dgt.power/Program.cs:line 141"
+            // We want to remove the path before the filename.
+            var inIndex = lines[i].LastIndexOf(" in ", StringComparison.Ordinal);
+            if (inIndex != -1)
+            {
+                var pathPart = lines[i][(inIndex + 4)..];
+                var colonIndex = pathPart.LastIndexOf(':');
+                if (colonIndex != -1)
+                {
+                    var filePart = pathPart[..colonIndex];
+                    var linePart = pathPart[colonIndex..];
+                    var lastSeparator = filePart.LastIndexOfAny(['/', '\\']);
+                    if (lastSeparator != -1)
+                    {
+                        lines[i] = lines[i][..(inIndex + 4)] + filePart[(lastSeparator + 1)..] + linePart;
+                    }
+                }
+            }
+        }
+
+        var result = string.Join(Environment.NewLine, lines);
+        return Anonymize(result);
+    }
+
+    private static string StripToFileName(string path, char separator)
+    {
+        var lastSeparator = path.LastIndexOf(separator);
+        return lastSeparator == -1 ? path : path[(lastSeparator + 1)..];
+    }
+
+    [GeneratedRegex(@"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")]
+    private static partial Regex GetGuidRegex();
+
+    // Matches https://<org>[.api].crm[N].dynamics.com(/path?query) - covers all regional CRM instance
+    // suffixes (crm, crm2, crm3, ... crm11) as well as the plain "dynamics.com" apex used by some admin APIs.
+    // The optional path/query is matched non-greedily and must not swallow trailing sentence punctuation
+    // (e.g. the "." that ends "... systemusers.").
+    [GeneratedRegex(@"https?://[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.(?:crm\d{0,2}\.)?dynamics\.com(?:/[^\s'""<>]*[^\s'""<>.,;:!?)])?", RegexOptions.IgnoreCase)]
+    private static partial Regex GetDataverseOrgUrlRegex();
+
+    // Matches https://<tenant>.onmicrosoft.com(/path?query) - Entra ID (Azure AD) tenant URLs, which also
+    // identify the customer.
+    [GeneratedRegex(@"https?://[A-Za-z0-9-]+\.onmicrosoft\.com(?:/[^\s'""<>]*[^\s'""<>.,;:!?)])?", RegexOptions.IgnoreCase)]
+    private static partial Regex GetEntraTenantUrlRegex();
+
+    [GeneratedRegex(@"(?<![:\w])/(?:Users|home|root)/[^\s'""<>:]+", RegexOptions.IgnoreCase)]
+    private static partial Regex GetUnixHomePathRegex();
+
+    [GeneratedRegex(@"[A-Za-z]:\\Users\\[^\s'""<>:]+", RegexOptions.IgnoreCase)]
+    private static partial Regex GetWindowsHomePathRegex();
+
+    [GeneratedRegex(@"\r\n|\r|\n")]
+    private static partial Regex LineSplitRegex();
+}

--- a/src/dgt.power/Tracer.cs
+++ b/src/dgt.power/Tracer.cs
@@ -68,7 +68,61 @@ internal sealed class Tracer(bool telemetryEnabled = false, string? installId = 
     {
         var error = e.RootException();
         _console.WriteException(error);
-        _currentActivity?.SetStatus(ActivityStatusCode.Error, error.Message);
+        if (IsActive && _currentActivity != null)
+        {
+            var anonymizedMessage = TelemetryAnonymizer.Anonymize(error.Message);
+            var anonymizedStackTrace = TelemetryAnonymizer.AnonymizeStackTrace(error.StackTrace);
+
+            _currentActivity.SetStatus(ActivityStatusCode.Error, anonymizedMessage);
+            RecordException(_currentActivity, error, anonymizedMessage, anonymizedStackTrace, escaped: false);
+        }
+    }
+
+    public void TrackFatalException(Exception e)
+    {
+        if (!IsActive) return;
+
+        var error = e.RootException();
+        using var activity = DgtpActivitySource.Instance.StartActivity("fatal_exception");
+        if (activity != null)
+        {
+            activity.SetTag("dgtp.is_ci", TelemetryConfig.IsCi);
+            activity.SetTag("dgtp.os", Environment.OSVersion.Platform.ToString());
+            activity.SetTag("dgtp.version", DgtpActivitySource.Instance.Version);
+            if (installId != null)
+            {
+                activity.SetTag("dgtp.install_id", installId);
+            }
+
+            var anonymizedMessage = TelemetryAnonymizer.Anonymize(error.Message);
+            var anonymizedStackTrace = TelemetryAnonymizer.AnonymizeStackTrace(error.StackTrace);
+
+            activity.SetStatus(ActivityStatusCode.Error, anonymizedMessage);
+            RecordException(activity, error, anonymizedMessage, anonymizedStackTrace, escaped: true);
+        }
+    }
+
+    /// <summary>
+    /// Records the exception both as tags (for quick filtering on the enclosing span/dependency via
+    /// customDimensions) and as an OpenTelemetry "exception" event following the standard semantic
+    /// conventions (<c>exception.type</c>, <c>exception.message</c>, <c>exception.stacktrace</c>,
+    /// <c>exception.escaped</c>). The Azure Monitor exporter turns exception *events* - but not plain
+    /// tags - into proper entries in the Application Insights "exceptions" table / Failures blade.
+    /// </summary>
+    private static void RecordException(Activity activity, Exception error, string anonymizedMessage, string anonymizedStackTrace, bool escaped)
+    {
+        activity.SetTag("exception.type", error.GetType().FullName);
+        activity.SetTag("exception.message", anonymizedMessage);
+        activity.SetTag("exception.stacktrace", anonymizedStackTrace);
+
+        var tags = new ActivityTagsCollection
+        {
+            { "exception.type", error.GetType().FullName },
+            { "exception.message", anonymizedMessage },
+            { "exception.stacktrace", anonymizedStackTrace },
+            { "exception.escaped", escaped }
+        };
+        activity.AddEvent(new ActivityEvent("exception", tags: tags));
     }
 
     private void EndActivity(bool success)

--- a/tests/dgt.power.cli.tests/TelemetryAnonymizerTests.cs
+++ b/tests/dgt.power.cli.tests/TelemetryAnonymizerTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) DIGITALL Nature. All rights reserved
+// DIGITALL Nature licenses this file to you under the Microsoft Public License.
+
+using dgt.power.Telemetry;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+
+namespace dgt.power.cli.tests;
+
+public class TelemetryAnonymizerTests
+{
+    [Test]
+    public async Task Anonymize_WithGuid_ReplacesWithZeros()
+    {
+        const string input = "Error in record 12345678-1234-1234-1234-1234567890ab occurred.";
+        var result = TelemetryAnonymizer.Anonymize(input);
+
+        await Assert.That(result).IsEqualTo("Error in record 00000000-0000-0000-0000-000000000000 occurred.");
+    }
+
+    [Test]
+    public async Task AnonymizeStackTrace_WithAbsolutePaths_StripsPaths()
+    {
+        const string stackTrace = @"   at dgt.power.Program.Main(String[] args) in /Users/jdoe/Source/dgtp/src/dgt.power/Program.cs:line 141
+   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)";
+
+        var result = TelemetryAnonymizer.AnonymizeStackTrace(stackTrace);
+
+        await Assert.That(result).Contains("at dgt.power.Program.Main(String[] args) in Program.cs:line 141");
+        await Assert.That(result).DoesNotContain("/Users/jdoe/Source/dgtp/src/dgt.power/");
+    }
+
+    [Test]
+    public async Task AnonymizeStackTrace_WithWindowsPaths_StripsPaths()
+    {
+        const string stackTrace = @"   at dgt.power.Program.Main(String[] args) in C:\Users\jdoe\Source\dgtp\src\dgt.power\Program.cs:line 141";
+
+        var result = TelemetryAnonymizer.AnonymizeStackTrace(stackTrace);
+
+        await Assert.That(result).Contains("at dgt.power.Program.Main(String[] args) in Program.cs:line 141");
+        await Assert.That(result).DoesNotContain("C:\\Users\\jdoe\\Source\\dgtp\\src\\dgt.power\\");
+    }
+
+    [Test]
+    public async Task AnonymizeStackTrace_WithMixedLineEndings_StripsAllFrames()
+    {
+        // Simulates a stack trace that mixes \n-only lines with the platform's Environment.NewLine,
+        // e.g. because it was captured on a different OS or crossed a serialization boundary.
+        const string stackTrace = "   at Foo.Bar() in /Users/jdoe/src/Foo.cs:line 10\n" +
+                                   "   at Baz.Qux() in /Users/jdoe/src/Baz.cs:line 20\r\n" +
+                                   "   at Program.Main() in /Users/jdoe/src/Program.cs:line 30";
+
+        var result = TelemetryAnonymizer.AnonymizeStackTrace(stackTrace);
+
+        await Assert.That(result).Contains("in Foo.cs:line 10");
+        await Assert.That(result).Contains("in Baz.cs:line 20");
+        await Assert.That(result).Contains("in Program.cs:line 30");
+        await Assert.That(result).DoesNotContain("/Users/jdoe/");
+    }
+
+    [Test]
+    public async Task Anonymize_WithUnixHomePath_StripsUsernameFromMessage()
+    {
+        const string input = "Could not find file '/Users/jdoe/secret/config.json'.";
+
+        var result = TelemetryAnonymizer.Anonymize(input);
+
+        await Assert.That(result).IsEqualTo("Could not find file 'config.json'.");
+        await Assert.That(result).DoesNotContain("jdoe");
+    }
+
+    [Test]
+    public async Task Anonymize_WithLinuxHomePath_StripsUsernameFromMessage()
+    {
+        const string input = "Access denied to /home/ciuser/workspace/output.xml";
+
+        var result = TelemetryAnonymizer.Anonymize(input);
+
+        await Assert.That(result).IsEqualTo("Access denied to output.xml");
+        await Assert.That(result).DoesNotContain("ciuser");
+    }
+
+    [Test]
+    public async Task Anonymize_WithWindowsHomePath_StripsUsernameFromMessage()
+    {
+        const string input = @"Could not find a part of the path 'C:\Users\jdoe\secret\config.json'.";
+
+        var result = TelemetryAnonymizer.Anonymize(input);
+
+        await Assert.That(result).IsEqualTo("Could not find a part of the path 'config.json'.");
+        await Assert.That(result).DoesNotContain("jdoe");
+    }
+
+    [Test]
+    public async Task Anonymize_WithDataverseOrgUrl_RedactsOrgUrl()
+    {
+        const string input = "The user is not enabled to access the environment https://contoso.crm4.dynamics.com/api/data/v9.2/systemusers.";
+
+        var result = TelemetryAnonymizer.Anonymize(input);
+
+        await Assert.That(result).IsEqualTo("The user is not enabled to access the environment [dataverse-org-url-redacted].");
+        await Assert.That(result).DoesNotContain("contoso");
+    }
+
+    [Test]
+    public async Task Anonymize_WithEntraTenantUrl_RedactsTenantUrl()
+    {
+        const string input = "Failed to authenticate against https://contoso.onmicrosoft.com/adfs/token.";
+
+        var result = TelemetryAnonymizer.Anonymize(input);
+
+        await Assert.That(result).IsEqualTo("Failed to authenticate against [entra-tenant-url-redacted].");
+        await Assert.That(result).DoesNotContain("contoso");
+    }
+
+    [Test]
+    public async Task Anonymize_WithUnrelatedUrl_LeavesUrlUntouched()
+    {
+        // Guards against the home-path regex over-matching generic URLs (e.g. nuget.org / github.com
+        // links that regularly show up in version-check or network related exception messages).
+        const string input = "Failed to reach https://api.nuget.org/v3/index.json";
+
+        var result = TelemetryAnonymizer.Anonymize(input);
+
+        await Assert.That(result).IsEqualTo(input);
+    }
+}

--- a/tests/dgt.power.tests/TestTracer.cs
+++ b/tests/dgt.power.tests/TestTracer.cs
@@ -45,4 +45,11 @@ public class TestTracer : ITracer
         Console.WriteLine($"{type}: {error.Message}");
         Console.WriteLine($"{type}: {error.StackTrace}");
     }
+
+    public void TrackFatalException(Exception e)
+    {
+        var error = e.RootException();
+        Console.WriteLine($"FATAL: {error.Message}");
+        Console.WriteLine($"FATAL: {error.StackTrace}");
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up hardening for the crash/error telemetry introduced earlier: closes the privacy gaps found during a self-audit of the anonymization logic and makes crashes properly discoverable in Application Insights.

## Changes

- **Path anonymization gap fixed**: `Anonymize()` (message-level) previously only stripped GUIDs. Exception messages (e.g. `DirectoryNotFoundException`, `FileNotFoundException`) frequently embed the full local path including the OS username - these are now stripped down to just the file name for `/Users/<name>/...`, `/home/<name>/...`, `/root/...` and `C:\Users\<name>\...`.
- **Dataverse org / Entra tenant URL redaction**: `https://<org>.crmN.dynamics.com/...` and `https://<tenant>.onmicrosoft.com/...` URLs - which directly identify the customer - are now replaced with fixed placeholders instead of being transmitted as-is.
- **Cross-platform stack trace splitting fix**: `AnonymizeStackTrace` now splits on any line ending (`\r\n|\r|\n`) instead of `Environment.NewLine`, so a stack trace with different line endings than the current OS is still processed frame-by-frame (previously it silently fell back to treating the whole trace as one line, leaving earlier frames' paths unstripped).
- **Exceptions now recorded as OpenTelemetry exception events**: in addition to span tags, `Tracer.Exception`/`Tracer.TrackFatalException` add a standard `exception` `ActivityEvent`. The Azure Monitor exporter only projects exception events (not plain tags) into the Application Insights `exceptions` table / Failures blade - without this, crashes were only visible as custom dimensions on a `dependency` row.
- **README**: documents the exact anonymization scope/placeholders and adds a "Retrieving crash/error data in Application Insights" section with ready-to-use KQL queries against the `exceptions` table.
- **`.memory`**: decision doc and summary updated to reflect the new anonymization scope and known limitations.

## Testing

- `dotnet build` - solution builds with 0 warnings/errors.
- `dotnet test tests/dgt.power.cli.tests` - 135/135 passed, including new coverage for home-path stripping (Unix/Windows), org/tenant URL redaction, mixed line-ending stack traces, and a regression guard ensuring unrelated URLs (e.g. api.nuget.org) are left untouched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
