### PR TITLE
Modify DotNetGenerator to include all requests

### DIFF
--- a/src/modules/dgt.power.codegeneration/Generators/DotNetGenerator.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/DotNetGenerator.cs
@@ -62,21 +62,14 @@ public class DotNetGenerator(IMetadataService metadataService, IAnsiConsole cons
         }
 
         var requests = metadataService.RetrieveRequests(config.Requests);
-
-        // Only generate request/response classes for entries that have parameters
-        var requestsWithParams = requests.Where(r => r.InParameters.Count > 0 || r.OutParameters.Count > 0).ToArray();
-        if (requestsWithParams.Length == 0)
-        {
-            return;
-        }
-
+       
         var fileName = Path.Combine(args.TargetDirectory, args.Folder, Folders.DotNet, $"{DotNet.Actions}.cs");
         console.MarkupLine($"Creating File: [bold green]{fileName}[/]");
 
         using var file = File.CreateText(fileName);
         var context = DotNetLiquidRenderer.CreateContext();
         context.SetValue("NameSpace", config.Namespace);
-        context.SetValue("Actions", requestsWithParams);
+        context.SetValue("Actions", requests);
 
         var content = DotNetLiquidRenderer.Render("Action.dotnet.liquid", context);
         file.Write(content);


### PR DESCRIPTION
Updated the DotNetGenerator to generate classes for all requests instead of only those with parameters because entity bound actions might have no parameters. In our D365 environments we some custom actions that are entity bound and have no params, even no Target property. For these Actions the version 2.1.0 does not generate Request/Response classes while version 2.0.0 did. 