### PR TITLE
fix(ts): add warning when user language mismatches base language

### DIFF
--- a/.memory/research-form-language-localization.md
+++ b/.memory/research-form-language-localization.md
@@ -1,0 +1,71 @@
+# Research: Form/label language localization in codegeneration (TypeScript)
+
+## Context
+
+`dgt.power.codegeneration`'s TypeScript strategies (`TypescriptLightGenerationStrategy`,
+`TypescriptFullGenerationStrategy`) generate form typings and option-set label constants for
+Dataverse entities. Both V1 (`CodeGenerationConfig.UseBaseLanguage`) and V2
+(`TypeScriptCodeGenerationConfig.Language`) configs let users pin the LCID used for label
+resolution, or fall back to the org's base language.
+
+## Two distinct localization mechanisms in Dataverse — do not confuse them
+
+1. **Metadata `Label`/`LocalizedLabels`** (attribute display names, option set option labels,
+   entity display names). These genuinely support per-request LCID resolution:
+   `Formatter.GetLocalizedLabel(Label, useBaseLanguage, lcid)` and the Fluid filter
+   `CustomLiquidFilters.Localize` (`{{ someLabel | localize: languageCode }}`) both call
+   `label.GetLocalizedLabel(lcid)`, correctly honoring the configured language. This mechanism
+   works and needs no connection/session tricks.
+
+2. **Record data attributes on out-of-box (OOB) records** (e.g. `systemform.name`, likely also
+   sitemap/ribbon/process names). These are **not** Label-backed. Dataverse resolves the returned
+   string based on the **connecting user's personal UI language** (`usersettings.uilanguageid`),
+   NOT any per-request parameter, and NOT the org base language directly. There is no supported way
+   to override this per-`RetrieveMultiple`-call in the SDK for .NET — no `LanguageCode` parameter
+   exists on `RetrieveMultipleRequest`/`QueryExpression`.
+
+## Consequence / bug found
+
+`FormParser`/`MetadataService.ParseSystemFormsCollectionToFormDetails` builds the internal form key
+(`FormDetail.FormUniqueName`, used both for the generated file name and for matching `config.Forms`
+include/exclude entries) directly from `systemform.name`. If the connecting user's UI language
+differs from the language configured for code generation (`language`/`UseBaseLanguage`), the
+retrieved form name is in a *different* language than what the user wrote in `config.Forms`,
+causing matching to silently fail and forms to be skipped ("fall through the filtering").
+
+## Considered fixes and why they were rejected
+
+- **Impersonate/mutate `usersettings.uilanguageid` before retrieval, restore after** — the only
+  known mechanism that would make `systemform.name` actually return in the target language. Rejected
+  by the user: too invasive (mutates a real connected user's account state, even if restored),
+  and could interfere with concurrent usage in shared/dev environments.
+- **Use `systemform.uniquename` instead of `name` for the stable/language-independent key** —
+  `uniquename` is documented to be language-independent, but was found to be unreliably populated
+  in practice (many system forms have it empty). Rejected.
+- **Allow `config.Forms` entries to be a FormId GUID as an alternate match key** — technically
+  solid but not pursued; user preferred documenting the limitation instead.
+
+## Fix implemented (final)
+
+Treated as a **known, documented Dataverse platform limitation** rather than something to silently
+work around:
+
+- Added `IMetadataService.RetrieveConnectionUserLanguage()` — read-only, uses `WhoAmIRequest` +
+  retrieves `usersettings` for that user's `uilanguageid` (falls back to org base language if null).
+- Both TypeScript strategies now compare this session language against the configured language
+  right before generating forms, and print `Warnings.FormNameLanguageMismatch(...)` via
+  `Console.MarkupLine` when they differ.
+- Documented in `README.md` under `codegeneration` → "Known limitations", with the mitigation
+  (set the connecting user's personal Dataverse UI language to match the configured `language`).
+
+## Separate, already-fixed bug (root cause of the *original* report)
+
+Independent of the above: `FormViewModel` had no `LanguageCode` property at all, so the
+`{{ option.Label | localize: LanguageCode }}` filter call in `EntityFormTestHelper.liquid` always
+resolved `LanguageCode` to `null`/default, silently ignoring the configured language for option
+labels rendered in form test helpers. Fixed by adding `FormViewModel.LanguageCode` and threading the
+strategy-computed `languageCode` into it (`TypescriptLightGenerationStrategy.CreateFormFileContent`).
+The "Full"/V2-old generator (`TypescriptFullGenerationStrategy.GenerateFormDetailFile`) had an
+analogous bug: it hardcoded `metadataService.RetrieveOrganizationLanguage()` for
+`TsLiquidTemplateModelFactory.CreateEntityFormModel(...)`'s `systemLanguage` parameter, ignoring
+`config.UseBaseLanguage`/override — fixed by passing through the already-computed `languageCode`.

--- a/.memory/summary.md
+++ b/.memory/summary.md
@@ -173,6 +173,7 @@ The TypeScript/Liquid (TSL) template engine has enterprise-grade hardening:
 | `research-servicepointmanager-dotnet8.md` | research | ServicePointManager no-op; Dataverse.Client has no HttpClient hook |
 | `research-tsl-fluid-hardening.md` | research | Fluid.Core stability assessment and hardening strategy |
 | `research-v2-typescript-config-design-gaps.md` | research | Current V2 TS caveats after redesign: no `TypingPath`, no per-entity filters, string-based `forms.filter` |
+| `research-form-language-localization.md` | research | Metadata `Label` LCID resolution vs. OOB record data (`systemform.name`) being session-UI-language dependent, not per-request; `FormViewModel.LanguageCode` gap fix; known limitation + warning for form name/config.Forms matching |
 | `implementation-v2-codegeneration-config-shape.md` | implementation | Final nested V2 config shape: shared `entities` scope, `optionSets`, and target-specific `output` blocks |
 | `implementation-v2-schema-allows-dollar-schema.md` | implementation | V2 schemas now allow top-level `$schema` for editor compatibility under `additionalProperties: false` |
 | `decision-error-telemetry-anonymization.md` | decision | Crash reporting via OTel exception events; anonymization scope (GUIDs, home-dir paths, org/tenant URLs) and known limitations |

--- a/README.md
+++ b/README.md
@@ -515,6 +515,24 @@ V1 configs use a single file for both .NET and TypeScript output and are detecte
 | `DGT_POWER_TSL_STRICT_MODE` | Enables fail-fast handling for undefined Liquid values (`1` / `true` / `yes`) | Falls back to CI-agent detection |
 | `DGT_POWER_TSL_MAX_STEPS` | Overrides Fluid template execution step limit with a positive integer | `20000` |
 
+#### Known limitations
+
+**Form names depend on the connection's UI language, not the configured `language`.** Dataverse resolves the
+`name` attribute of out-of-box records (including system forms) using the *connecting user's personal UI
+language setting* (`usersettings.uilanguageid`), not any per-request parameter. This means:
+
+- Labels rendered *inside* generated form/option-set typings (e.g. option set labels) correctly follow the
+  `language`/`UseBaseLanguage` config value, since those come from metadata `Label`/`LocalizedLabels`, which
+  *do* support per-request LCID resolution.
+- The system form's own `name` — used to build the generated file name and to match entries in `Forms` —
+  is retrieved in whatever language the connecting user's Dataverse profile is set to. If that differs from
+  the language configured for code generation, form names may not match `Forms` filter entries, and matching
+  forms can be silently skipped.
+
+`dgtp` detects this mismatch and prints a warning at generation time when the connection's UI language differs
+from the configured language. **Mitigation:** set the connecting user's personal Dataverse UI language (Settings
+→ Personalization Settings → Language) to match the `language` configured for code generation.
+
 ### `push` — Deploy artifacts
 
 Pushes a plugin assembly or web resource into a target solution.

--- a/src/modules/dgt.power.codegeneration/Constants/Warnings.cs
+++ b/src/modules/dgt.power.codegeneration/Constants/Warnings.cs
@@ -7,4 +7,18 @@ public static class Warnings
 {
     public static string TsExtensionDeprecation =>
         "Warning: some Forms end with '.ts', please remove the '.ts' in your config! It's deprecated!";
+
+    /// <summary>
+    ///     Dataverse resolves the <c>name</c> attribute of out-of-box records (e.g. system forms) based on the
+    ///     connecting user's personal UI language setting, not on any per-request language parameter. If that
+    ///     session language differs from the language configured for code generation, form names retrieved from
+    ///     Dataverse may not match `Forms` entries in the config, causing forms to be silently skipped. This is a
+    ///     known Dataverse platform limitation - see README for details and mitigation.
+    /// </summary>
+    public static string FormNameLanguageMismatch(int sessionLanguageCode, int configuredLanguageCode) =>
+        $"[bold yellow]Warning:[/] Your Dataverse connection's UI language ({sessionLanguageCode}) differs from " +
+        $"the configured code generation language ({configuredLanguageCode}). Form names (systemform.name) are " +
+        "resolved by Dataverse using the connection's UI language, not the configured language - form filtering " +
+        "via 'Forms' in the config may skip forms unexpectedly. Set your personal Dataverse UI language to match " +
+        "the configured language to avoid this. See README 'Known Limitations' section for details.";
 }

--- a/src/modules/dgt.power.codegeneration/Generators/Strategy/TypescriptFullGenerationStrategy.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Strategy/TypescriptFullGenerationStrategy.cs
@@ -182,7 +182,7 @@ public class TypescriptFullGenerationStrategy(IMetadataService metadataService, 
         var entityMetadata =
                 metadataService.RetrieveEntityMetadata(entityLogicalName, EntityFilters.Attributes | EntityFilters.Entity);
 
-        int languageCode = config.UseBaseLanguage
+        var languageCode = config.UseBaseLanguage
             ? metadataService.RetrieveOrganizationLanguage()
             : 1031;
 

--- a/src/modules/dgt.power.codegeneration/Generators/Strategy/TypescriptFullGenerationStrategy.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Strategy/TypescriptFullGenerationStrategy.cs
@@ -182,13 +182,23 @@ public class TypescriptFullGenerationStrategy(IMetadataService metadataService, 
         var entityMetadata =
                 metadataService.RetrieveEntityMetadata(entityLogicalName, EntityFilters.Attributes | EntityFilters.Entity);
 
+        int languageCode = config.UseBaseLanguage
+            ? metadataService.RetrieveOrganizationLanguage()
+            : 1031;
+
+        var sessionLanguageCode = metadataService.RetrieveConnectionUserLanguage();
+        if (sessionLanguageCode != languageCode)
+        {
+            Console.MarkupLine(Warnings.FormNameLanguageMismatch(sessionLanguageCode, languageCode));
+        }
+
         var forms = config.OnlyFormsFromSolutions
             ? metadataService.RetrieveFormsDetailsFromSolutions(entityMetadata.LogicalName, [.. config.Solutions], null)
             : metadataService.RetrieveFormsDetails(entityMetadata.LogicalName, null);
 
         foreach (var formDetail in forms)
         {
-            GenerateFormDetailFile(args, config, entityMetadata, formDetail);
+            GenerateFormDetailFile(args, config, entityMetadata, formDetail, languageCode);
         }
     }
 
@@ -199,7 +209,8 @@ public class TypescriptFullGenerationStrategy(IMetadataService metadataService, 
     /// <param name="config"></param>
     /// <param name="entityMetadata"></param>
     /// <param name="formDetail"></param>
-    private void GenerateFormDetailFile(CodeGenerationVerb args, CodeGenerationConfig config, EntityMetadata entityMetadata, KeyValuePair<string, FormDetail> formDetail)
+    /// <param name="languageCode">Language LCID to use for localizing option set labels rendered on the form.</param>
+    private void GenerateFormDetailFile(CodeGenerationVerb args, CodeGenerationConfig config, EntityMetadata entityMetadata, KeyValuePair<string, FormDetail> formDetail, int languageCode)
     {
         var form =
                $"{entityMetadata.LogicalName}.{Formatter.Sanitize(formDetail.Key.ToLowerInvariant(), true).Replace(' ', '_')}.{FileNames.Typescript.FileNamePart.Form}";
@@ -227,7 +238,7 @@ public class TypescriptFullGenerationStrategy(IMetadataService metadataService, 
             .Replace(".quickcreate", "QuickCreate", StringComparison.Ordinal);
 
 
-        var model = TsLiquidTemplateModelFactory.CreateEntityFormModel(config.TypingPath, form, formname, formDetail.Value, entityMetadata, config, metadataService.RetrieveOrganizationLanguage());
+        var model = TsLiquidTemplateModelFactory.CreateEntityFormModel(config.TypingPath, form, formname, formDetail.Value, entityMetadata, config, languageCode);
         CreateLiquidTemplateFile("D365EntityForm.liquid", model, form, args);
     }
 }

--- a/src/modules/dgt.power.codegeneration/Generators/Strategy/TypescriptLightGenerationStrategy.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Strategy/TypescriptLightGenerationStrategy.cs
@@ -108,7 +108,7 @@ public class TypescriptLightGenerationStrategy(IMetadataService metadataService,
         var liquidTemplateForm = InitializeLiquidTemplate(LiquidTemplates.EntityForm);
         var liquidTemplateFormTestHelpers = InitializeLiquidTemplate(LiquidTemplates.EntityFormTestHelper);
 
-        int languageCode = 1031;
+        var languageCode = 1031;
         if (config.UseBaseLanguage)
         {
             languageCode = metadataService.RetrieveOrganizationLanguage();
@@ -372,7 +372,7 @@ public class TypescriptLightGenerationStrategy(IMetadataService metadataService,
         var liquidTemplateForm = InitializeLiquidTemplate(LiquidTemplates.EntityForm);
         var liquidTemplateFormTestHelpers = InitializeLiquidTemplate(LiquidTemplates.EntityFormTestHelper);
 
-        int languageCode = config.Language ?? metadataService.RetrieveOrganizationLanguage();
+        var languageCode = config.Language ?? metadataService.RetrieveOrganizationLanguage();
         Console.MarkupLine($"Using Language: {languageCode}");
 
         WarnIfSessionLanguageMismatch(languageCode);

--- a/src/modules/dgt.power.codegeneration/Generators/Strategy/TypescriptLightGenerationStrategy.cs
+++ b/src/modules/dgt.power.codegeneration/Generators/Strategy/TypescriptLightGenerationStrategy.cs
@@ -108,6 +108,15 @@ public class TypescriptLightGenerationStrategy(IMetadataService metadataService,
         var liquidTemplateForm = InitializeLiquidTemplate(LiquidTemplates.EntityForm);
         var liquidTemplateFormTestHelpers = InitializeLiquidTemplate(LiquidTemplates.EntityFormTestHelper);
 
+        int languageCode = 1031;
+        if (config.UseBaseLanguage)
+        {
+            languageCode = metadataService.RetrieveOrganizationLanguage();
+            Console.MarkupLine($"Using Base Language: {languageCode}");
+        }
+
+        WarnIfSessionLanguageMismatch(languageCode);
+
         var bpfControls = GetCompleteEntityBpfControlList(config);
         var entityWithParsedFormList = GenerateEntityWithMetadata(config, bpfControls);
         var flatListParseForm = GetFlatFormDetail(entityWithParsedFormList);
@@ -125,11 +134,11 @@ public class TypescriptLightGenerationStrategy(IMetadataService metadataService,
                     continue;
                 }
                 FormParser.MapQuickFormId(parsedForm.Value, flatListParseForm);
-                CreateFormFile(parsedForm, entityMetadata, liquidTemplateForm, LiquidTemplates.EntityForm, args, formName, bpfControlsForEntity);
+                CreateFormFile(parsedForm, entityMetadata, liquidTemplateForm, LiquidTemplates.EntityForm, args, formName, bpfControlsForEntity, languageCode);
                 if (config.XrmMockFormHelpers)
                 {
                     CreateFormTestHelperFile(parsedForm, entityMetadata, liquidTemplateFormTestHelpers, LiquidTemplates.EntityFormTestHelper, args,
-                        $"{formName}.{FileNames.Typescript.FileNamePart.TestHelper}", bpfControlsForEntity);
+                        $"{formName}.{FileNames.Typescript.FileNamePart.TestHelper}", bpfControlsForEntity, languageCode);
                 }
             }
         }
@@ -363,6 +372,11 @@ public class TypescriptLightGenerationStrategy(IMetadataService metadataService,
         var liquidTemplateForm = InitializeLiquidTemplate(LiquidTemplates.EntityForm);
         var liquidTemplateFormTestHelpers = InitializeLiquidTemplate(LiquidTemplates.EntityFormTestHelper);
 
+        int languageCode = config.Language ?? metadataService.RetrieveOrganizationLanguage();
+        Console.MarkupLine($"Using Language: {languageCode}");
+
+        WarnIfSessionLanguageMismatch(languageCode);
+
         var bpfControls = GetCompleteEntityBpfControlListV2(config);
         var entityWithParsedFormList = GenerateEntityWithMetadataV2(config, bpfControls);
         var flatListParseForm = GetFlatFormDetail(entityWithParsedFormList);
@@ -387,7 +401,8 @@ public class TypescriptLightGenerationStrategy(IMetadataService metadataService,
                     LiquidTemplates.EntityForm,
                     args,
                     formName,
-                    bpfControlsForEntity);
+                    bpfControlsForEntity,
+                    languageCode);
                 if (config.Output.Forms?.TestHelpers ?? false)
                 {
                     CreateFormTestHelperFile(
@@ -397,7 +412,8 @@ public class TypescriptLightGenerationStrategy(IMetadataService metadataService,
                         LiquidTemplates.EntityFormTestHelper,
                         args,
                         $"{formName}.{FileNames.Typescript.FileNamePart.TestHelper}",
-                        bpfControlsForEntity);
+                        bpfControlsForEntity,
+                        languageCode);
                 }
             }
         }
@@ -572,10 +588,11 @@ public class TypescriptLightGenerationStrategy(IMetadataService metadataService,
         string templateName,
         CodeGenerationVerb args,
         string form,
-        SortedSet<BpfControlDetail> bpfControls)
+        SortedSet<BpfControlDetail> bpfControls,
+        int languageCode)
     {
         var artifact = $"{form}.{FileNames.Typescript.FileExtension.TypeExtension}";
-        var content = CreateFormFileContent(formDetail, metadata, liquidTemplate, templateName, bpfControls, artifact);
+        var content = CreateFormFileContent(formDetail, metadata, liquidTemplate, templateName, bpfControls, artifact, languageCode);
         CreateFile(content, form, args, FileNames.Typescript.FileExtension.TypeExtension, GetEntityFolderName(metadata.LogicalName, Folders.TypescriptEntityForms));
     }
 
@@ -586,10 +603,11 @@ public class TypescriptLightGenerationStrategy(IMetadataService metadataService,
         string templateName,
         CodeGenerationVerb args,
         string form,
-        SortedSet<BpfControlDetail> bpfControls)
+        SortedSet<BpfControlDetail> bpfControls,
+        int languageCode)
     {
         var artifact = $"{form}.{FileNames.Typescript.FileExtension.TsExtension}";
-        var content = CreateFormFileContent(formDetail, metadata, liquidTemplate, templateName, bpfControls, artifact);
+        var content = CreateFormFileContent(formDetail, metadata, liquidTemplate, templateName, bpfControls, artifact, languageCode);
         CreateFile(content, form, args, FileNames.Typescript.FileExtension.TsExtension, GetEntityFolderName(metadata.LogicalName, Folders.TypescriptEntityTestHelper));
     }
 
@@ -599,7 +617,8 @@ public class TypescriptLightGenerationStrategy(IMetadataService metadataService,
         IFluidTemplate liquidTemplate,
         string templateName,
         SortedSet<BpfControlDetail> bpfControls,
-        string artifact)
+        string artifact,
+        int languageCode)
     {
         var formname = formDetail.Key
                     .Replace(".main", "Main", StringComparison.Ordinal)
@@ -611,7 +630,8 @@ public class TypescriptLightGenerationStrategy(IMetadataService metadataService,
             Name = formname,
             FormDetail = formDetail.Value,
             Attributes = FilterEntityMetadataAttributes(metadata),
-            BpfControls = formDetail.Value.FormType == SystemForm.Options.Type.QuickViewForm ? [] : bpfControls.ToList()
+            BpfControls = formDetail.Value.FormType == SystemForm.Options.Type.QuickViewForm ? [] : bpfControls.ToList(),
+            LanguageCode = languageCode
         };
         return RenderTemplateWithDiagnostics(
             liquidTemplate,
@@ -673,6 +693,20 @@ public class TypescriptLightGenerationStrategy(IMetadataService metadataService,
     {
         var formEntityName = entityLogicalName.ToLowerInvariant().Trim();
         return [Folders.TypescriptEntities, Formatter.CamelCase(Formatter.Sanitize(formEntityName)), subFolder];
+    }
+
+    /// <summary>
+    ///     Warns once when the connecting user's session UI language differs from the language configured for
+    ///     code generation, since Dataverse resolves translatable out-of-box record text (e.g. system form
+    ///     <c>name</c>) using the session language - not the configured one. See <see cref="Warnings.FormNameLanguageMismatch"/>.
+    /// </summary>
+    private void WarnIfSessionLanguageMismatch(int configuredLanguageCode)
+    {
+        var sessionLanguageCode = metadataService.RetrieveConnectionUserLanguage();
+        if (sessionLanguageCode != configuredLanguageCode)
+        {
+            Console.MarkupLine(Warnings.FormNameLanguageMismatch(sessionLanguageCode, configuredLanguageCode));
+        }
     }
 
     private TemplateContext CreateTemplateContext(object viewModel)

--- a/src/modules/dgt.power.codegeneration/Services/Contracts/IMetadataService.cs
+++ b/src/modules/dgt.power.codegeneration/Services/Contracts/IMetadataService.cs
@@ -31,6 +31,14 @@ public interface IMetadataService
     EntityMetadata RetrieveEntityMetadata(string entity, EntityFilters filter = EntityFilters.Default);
     int RetrieveOrganizationLanguage();
 
+    /// <summary>
+    ///     Returns the UI language (LCID) of the currently connected user, as configured in their personal
+    ///     <c>usersettings</c>. Dataverse resolves translatable out-of-box record text (e.g. system form
+    ///     <c>name</c>) based on this session language, not on any per-request parameter - so it can differ
+    ///     from the language configured for code generation. Used to warn about this known limitation.
+    /// </summary>
+    int RetrieveConnectionUserLanguage();
+
     IReadOnlyList<Tuple<string, string, Guid, string>> RetrieveBusinessProcessFlows(IReadOnlyCollection<string> businessProcessFlows);
     /// <inheritdoc cref="RetrieveBusinessProcessFlows(IReadOnlyCollection{string})"/>
     IReadOnlyList<Tuple<string, string, Guid, string>> RetrieveBusinessProcessFlows(CodeGenerationConfig config);

--- a/src/modules/dgt.power.codegeneration/Services/MetadataService.cs
+++ b/src/modules/dgt.power.codegeneration/Services/MetadataService.cs
@@ -11,6 +11,7 @@ using dgt.power.codegeneration.Model;
 using dgt.power.codegeneration.Services.Contracts;
 using dgt.power.codegeneration.Templates;
 using dgt.power.dataverse;
+using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
@@ -69,6 +70,28 @@ public partial class MetadataService(IOrganizationService connection, ObjectCach
 
         return organization.Entities.Single().ToEntity<Organization>().LanguageCode!.Value;
     }
+
+    /// <inheritdoc />
+    /// <remarks>
+    ///     Best-effort/diagnostic only: falls back to the organization's base language if the connecting
+    ///     user's UI language cannot be determined (e.g. insufficient privileges, missing entity in test
+    ///     doubles), since this value is only used to emit a warning, never to control actual retrieval.
+    /// </remarks>
+#pragma warning disable CA1031 // Diagnostic-only best-effort lookup: any failure (privileges, missing metadata, connectivity) must not break generation, only skip the warning.
+    public int RetrieveConnectionUserLanguage()
+    {
+        try
+        {
+            var userId = ((WhoAmIResponse)connection.Execute(new WhoAmIRequest())).UserId;
+            var userSettings = connection.Retrieve("usersettings", userId, new ColumnSet("uilanguageid"));
+            return userSettings.GetAttributeValue<int?>("uilanguageid") ?? RetrieveOrganizationLanguage();
+        }
+        catch (Exception)
+        {
+            return RetrieveOrganizationLanguage();
+        }
+    }
+#pragma warning restore CA1031
 
 
     public IReadOnlyList<Tuple<string, string, List<Guid>>> RetrieveBusinessProcessFlowStages(Guid processId)

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/ViewModels/FormViewModel.cs
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/ViewModels/FormViewModel.cs
@@ -14,4 +14,5 @@ public record FormViewModel
     public required IReadOnlyList<BpfControlDetail> BpfControls { get; init; }
     public required FormDetail FormDetail { get; init; }
     public required string Name { get; init; }
+    public int LanguageCode { get; init; }
 }


### PR DESCRIPTION
systemforms are always retrieved using the connecting user's language. there is no way to override it on a request level. it breaks form filtering and can lead to missing form types. we have to treat it as a known issue.

1. adds a section to the readme about this behavior
2. prints a warning in terminal if there is a mismatch between languages

resolves #172