### PR TITLE
Add IgnoreDataMember attribute to Id property

### DIFF
--- a/src/modules/dgt.power.codegeneration/Templates/dotnet/Entity.dotnet.liquid
+++ b/src/modules/dgt.power.codegeneration/Templates/dotnet/Entity.dotnet.liquid
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
+using System.Runtime.Serialization;
 
 // ReSharper disable All
 namespace {{ NameSpace }}
@@ -41,6 +42,7 @@ namespace {{ NameSpace }}
 
         #region Attributes
         [AttributeLogicalName("{{ PrimaryIdAttribute }}")]
+        [IgnoreDataMember]
         public new {{ Virtual }}Guid Id
         {
             get


### PR DESCRIPTION
The generated early‑bound types inherit from Entity, which already declares public Guid Id as a [DataMember]. DataContractJsonSerializer walks the type hierarchy and finds two members with the same DataMember name "Id", so it throws an exception.