### PR TITLE
feat(codegen): improve generated TS mock form files and runtime helpers

### DIFF
--- a/.memory/implementation-175-ts-mock-form-improvements.md
+++ b/.memory/implementation-175-ts-mock-form-improvements.md
@@ -1,0 +1,157 @@
+# Implementation Plan: Issue #175 — TS Mock Form Improvements
+
+## Context
+
+Issue: https://github.com/DIGITALLNature/DigitallPower/issues/175
+Scope: Generated `*.mock.form.ts` files and the runtime TypeScript mock helpers in `src/modules/dgt.power.codegeneration/Templates/tsl/`.
+
+## Recommendation
+
+**Implement all six suggestions.** They are additive, do not break existing consumers, and significantly reduce boilerplate in Jest tests that use `XrmMockFormTestContextBuilder`.
+
+## Affected Files
+
+| File | Purpose |
+|------|---------|
+| `src/modules/dgt.power.codegeneration/Templates/tsl/EntityFormTestHelper.liquid` | Generates `*.mock.form.ts` files. |
+| `src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_test_context_types.ts` | Shared types, including `XrmFormMockServerData` and `IXrmMockFormTestContextBuilder`. |
+| `src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_test_context_builder.ts` | `XrmMockFormTestContextBuilder` implementation. |
+| `src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_odata_filter.ts` | OData filter logic for `retrieveMultipleRecords`. |
+| `tests/dgt.power.codegeneration.tests/TslTemplateContractTests.cs` | Template rendering smoke tests. |
+
+## Changes
+
+### 1. Factory function per mock form
+
+In `EntityFormTestHelper.liquid`, add an exported `createBuilder` function at the end of the namespace:
+
+```typescript
+export interface CreateBuilderOptions {
+    languageId?: number;
+}
+
+export function createBuilder(options?: CreateBuilderOptions): XrmForm.Tester.XrmMockFormTestContextBuilder<
+    {{FormClassNamespace}}.TabName,
+    {{FormClassNamespace}}.SectionNames,
+    {{FormClassNamespace}}.ControlName,
+    {{FormClassNamespace}}.AttributeName
+> {
+    const builder = new XrmMockFormTestContextBuilder(
+        [...FormControlTypesConfig],
+        [...FormAttributeTypesConfig],
+        [...TabSectionControlsConfig]
+    );
+
+    if (options?.languageId !== undefined) {
+        builder.withLanguageId(options.languageId);
+    }
+
+    return builder;
+}
+```
+
+Use conditional type arguments for `TabName` / `SectionNames` when tabs/sections are absent (fall back to `string`), matching the existing config types.
+
+### 2. Relax server mock types
+
+Change `XrmFormMockServerData` in `xrm_mock_form_test_context_types.ts`:
+
+```typescript
+export type XrmFormMockServerData = Record<string, unknown[]>;
+```
+
+Update `IXrmMockFormTestContextBuilder.withServerData` signature accordingly. This removes the need for `as unknown as XrmTable.DTO.Table<string>[]` casts when using concrete generated DTO types.
+
+### 3. `retrieveMultipleRecords` without `$select` returns full records
+
+In `xrm_mock_form_odata_filter.ts`, change `executeRetrieveMultipleRecord` so that it only applies `$select` when at least one select field is present:
+
+```typescript
+const selectFields = XrmMockFormODataFilter.getSelectFieldNamesFromAstObject(astOptions);
+// only restrict to id when an explicit $select was provided
+if (selectFields.length === 0) {
+    return filteredItems; // or list when no filter
+}
+selectFields.push(`${entityLogicalName}id`);
+return filteredItems.map((x) => XrmMockFormODataFilter.selectProperties(x, selectFields));
+```
+
+This aligns the mock behavior with the real Web API, where omitting `$select` returns all columns.
+
+### 4. Re-export FormContext types
+
+In `EntityFormTestHelper.liquid`, add:
+
+```typescript
+export type FormContext = {{FormClassNamespace}}.FormContext;
+export type ControlName = {{FormClassNamespace}}.ControlName;
+export type AttributeName = {{FormClassNamespace}}.AttributeName;
+export type TabName = {{FormClassNamespace}}.TabName;
+export type SectionNames = {{FormClassNamespace}}.SectionNames;
+```
+
+Only emit `TabName` / `SectionNames` if the form actually has tabs/sections to keep the type resolvable.
+
+### 5. Helper for selected SubGrid rows
+
+Add `withSelectedSubGridRows` to `XrmMockFormTestContextBuilder` and to the `IXrmMockFormTestContextBuilder` interface:
+
+```typescript
+public withSelectedSubGridRows(name: TControlName, selectedIds: string[]): this {
+    return this.withSubGridMockRows<string>({
+        entityName: /* infer from control config if possible, else require parameter */,
+        subGridRowsAttributeConfig: [],
+        gridRows: selectedIds.map((id) => ({ entityId: id, subGridRowsAttributes: [] })),
+        selectedRowsIndexes: selectedIds.map((_, i) => i),
+    });
+}
+```
+
+The entity name can be taken from the existing control config where `type === "subgrid"` and `attributeName` / `name` map to the related entity. If the mapping is not available at runtime, add the entity name as a required parameter (`withSelectedSubGridRows(name, entityName, selectedIds)`).
+
+### 6. `languageId` in factory options
+
+Covered by the `CreateBuilderOptions` interface in change #1. The factory calls `builder.withLanguageId(languageId)` when provided.
+
+## Testing
+
+1. Update `TslTemplateContractTests.cs` expected fragments for `EntityFormTestHelper.liquid` to assert presence of:
+   - `export function createBuilder`
+   - `export type FormContext`
+   - `languageId`
+2. Add unit tests for `XrmMockFormODataFilter.executeRetrieveMultipleRecord` verifying:
+   - no `$select` returns all properties,
+   - `$select` still restricts fields and always includes the entity id.
+3. Add builder tests for `withSelectedSubGridRows` and `createBuilder` options.
+
+## Risks
+
+- **Type loosening (`Record<string, unknown[]>`):** Slightly weaker type safety, but the current type already forces casts; this is an ergonomic win.
+- **Behavior change in `$select`:** Real Web API returns all fields when `$select` is absent, so this is a correctness fix, not a breaking change.
+- **Template type conditionals:** Must keep `TabName` / `SectionNames` fallbacks consistent with the generated config types to avoid TypeScript errors in generated files.
+
+## Post-Implementation Review
+
+A subagent verification pass identified one critical fix that was applied:
+
+- **`withSelectedSubGridRows` now sets `this.isSubGridMethodsMock = true`** before delegating to `withSubGridMockRows`. Without this, `buildMockFormContext()` skips `InitSubGridConfigMockRows()` and selected rows are not initialized.
+
+Other findings from the review were pre-existing code-quality issues (e.g. `any` casts in Web API mocks, `==` in `XrmMockFormODataFilter`, import types) and were **not** introduced by Issue #175; they remain unchanged to keep the PR focused.
+
+## Commit Plan
+
+Suggested commits:
+
+```
+feat(codegen): add createBuilder factory and type re-exports to mock form helpers
+feat(mock): relax XrmFormMockServerData type to Record<string, unknown[]>
+fix(mock): return all fields in retrieveMultipleRecords when no $select is given
+feat(mock): add withSelectedSubGridRows helper
+```
+
+## Status
+
+Implemented and verified:
+- `dotnet build src/modules/dgt.power.codegeneration/dgt.power.codegeneration.csproj` succeeds (0 errors)
+- `dotnet test --project tests/dgt.power.codegeneration.tests/dgt.power.codegeneration.tests.csproj` passes (57 tests)
+

--- a/.memory/summary.md
+++ b/.memory/summary.md
@@ -179,3 +179,4 @@ The TypeScript/Liquid (TSL) template engine has enterprise-grade hardening:
 | `decision-error-telemetry-anonymization.md` | decision | Crash reporting via OTel exception events; anonymization scope (GUIDs, home-dir paths, org/tenant URLs) and known limitations |
 | `decision-generic-command-deprecation.md` | decision | `[DeprecatedCommand]` attribute + `DeprecationInterceptor`: how to deprecate any command/branch, and why argv-position detection was replaced |
 | `guide-persist-after-verify-connection-commands.md` | guide | `CreateConnectionCommand`/`CreateProfileCommand`: why `Save()` must run after connectivity check, not before; test pattern with Transient `IProfileManager` |
+| `implementation-175-ts-mock-form-improvements.md` | implementation | Issue #175 plan: factory function, relaxed server mock types, no-$select fix, type re-exports, SubGrid helper, languageId option |

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/EntityFormTestHelper.liquid
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/EntityFormTestHelper.liquid
@@ -12,6 +12,22 @@
 {%- if tabSections != "" and tabSections != "0" -%}{%- assign HasAnySection = true %}{%- endif %}
 
 export namespace XrmForm{{ FormEntityName }}{{FormType}}{{FormName}}TestHelper {
+    export type FormContext = {{FormClassNamespace}}.FormContext;
+    export type ControlName = {{FormClassNamespace}}.ControlName;
+    export type AttributeName = {{FormClassNamespace}}.AttributeName;
+    {%- if FormType != "QuickView" -%}
+    {%- if HasAnyTab == true %}
+    export type TabName = {{FormClassNamespace}}.TabName;
+    {%- endif %}
+    {%- if HasAnySection == true %}
+    export type SectionNames = {{FormClassNamespace}}.SectionNames;
+    {%- endif %}
+    {%- endif %}
+
+    export interface CreateBuilderOptions {
+        languageId?: number;
+    }
+
     {% if HasAnyControl == true %}
     export const FormControlNames: string[] = [{%- for formControl in FormDetail.FormControls  %}
         "{{ formControl.ControlName }}",{%- endfor %}
@@ -102,4 +118,23 @@ export namespace XrmForm{{ FormEntityName }}{{FormType}}{{FormName}}TestHelper {
             ],
         },{% endfor -%}
     ] as const;{%- endif %}{%- endif %}
+
+    export function createBuilder(options?: CreateBuilderOptions): XrmForm.Tester.XrmMockFormTestContextBuilder<
+        {%- if FormType != "QuickView" and HasAnyTab == true -%}{{FormClassNamespace}}.TabName{%- else -%}string{%- endif -%},
+        {%- if FormType != "QuickView" and HasAnyTab == true and HasAnySection == true -%}{{FormClassNamespace}}.SectionNames{%- else -%}string{%- endif -%},
+        {%- if HasAnyControl == true -%}{{FormClassNamespace}}.ControlName{%- else -%}string{%- endif -%},
+        {%- if HasAnyAttribute == true -%}{{FormClassNamespace}}.AttributeName{%- else -%}string{%- endif -%}
+    > {
+        const builder = new XrmMockFormTestContextBuilder(
+            [...FormControlTypesConfig],
+            [...FormAttributeTypesConfig],
+            [...TabSectionControlsConfig]
+        );
+
+        if (options?.languageId !== undefined) {
+            builder.withLanguageId(options.languageId);
+        }
+
+        return builder;
+    }
 }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_odata_filter.ts
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_odata_filter.ts
@@ -2,198 +2,289 @@
 
 export type TokenValue = string | number | boolean | null | undefined | Date;
 export class XrmMockFormODataFilter {
-    // Map OData operators to JS logic
-    private static readonly ops: Record<string, (a: TokenValue, b: TokenValue) => boolean> = {
-        [TokenType.EqualsExpression]: (a, b) => {
-            if (
-                a === b ||
-                ((a === null || a === undefined) && (b === null || b === undefined)) ||
-                a?.toLocaleString() === b?.toLocaleString()
-            ) {
-                return true;
-            }
-            return false;
-        },
-        [TokenType.NotEqualsExpression]: (a, b) => a != b, // to consider null/undefined
-        [TokenType.GreaterThanExpression]: (a, b) => {
-            if (a === undefined || a === null || b === undefined || b === null) {
-                return false;
-            }
-            return a > b;
-        },
-        [TokenType.GreaterOrEqualsExpression]: (a, b) => {
-            if (a === undefined || a === null || b === undefined || b === null) {
-                return false;
-            }
-            return a >= b;
-        },
-        [TokenType.LesserThanExpression]: (a, b) => {
-            if (a === undefined || a === null || b === undefined || b === null) {
-                return false;
-            }
-            return a < b;
-        },
-        [TokenType.LesserOrEqualsExpression]: (a, b) => {
-            if (a === undefined || a === null || b === undefined || b === null) {
-                return false;
-            }
-            return a <= b;
-        },
-    };
+	// Map OData operators to JS logic
+	private static readonly ops: Record<
+		string,
+		(a: TokenValue, b: TokenValue) => boolean
+	> = {
+		[TokenType.EqualsExpression]: (a, b) => {
+			if (
+				a === b ||
+				((a === null || a === undefined) && (b === null || b === undefined)) ||
+				a?.toLocaleString() === b?.toLocaleString()
+			) {
+				return true;
+			}
+			return false;
+		},
+		[TokenType.NotEqualsExpression]: (a, b) => a != b, // to consider null/undefined
+		[TokenType.GreaterThanExpression]: (a, b) => {
+			if (a === undefined || a === null || b === undefined || b === null) {
+				return false;
+			}
+			return a > b;
+		},
+		[TokenType.GreaterOrEqualsExpression]: (a, b) => {
+			if (a === undefined || a === null || b === undefined || b === null) {
+				return false;
+			}
+			return a >= b;
+		},
+		[TokenType.LesserThanExpression]: (a, b) => {
+			if (a === undefined || a === null || b === undefined || b === null) {
+				return false;
+			}
+			return a < b;
+		},
+		[TokenType.LesserOrEqualsExpression]: (a, b) => {
+			if (a === undefined || a === null || b === undefined || b === null) {
+				return false;
+			}
+			return a <= b;
+		},
+	};
 
-    public static executeRetrieveMultipleRecord(entityLogicalName: string, list: XrmTable.DTO.Table<string>[], oDataString: string): XrmTable.DTO.Table<string>[] {
-        try {
-            console.log(`Run next query in mock data ${oDataString}`);
-            const astObject = defaultParser.query(oDataString);
-            const astOptions = astObject.value.options ?? [];
-            const selectFields = XrmMockFormODataFilter.getSelectFieldNamesFromAstObject(astOptions);
-            selectFields.push(`${entityLogicalName}id`);
-            const filterOption = XrmMockFormODataFilter.getFilterFromAstObject(astOptions);
-            if (!filterOption) {
-                return list.map((x) => XrmMockFormODataFilter.selectProperties(x, selectFields));
-            }
-            const filteredItems = list.filter((item) => XrmMockFormODataFilter.filterListItem(item, filterOption));
-            return filteredItems.map((x) => XrmMockFormODataFilter.selectProperties(x, selectFields));
-        } catch (error) {
-            console.error(`Failed to parse the OData query ${error}`);
-            return list;
-        }
-    }
+	public static executeRetrieveMultipleRecord(
+		entityLogicalName: string,
+		list: XrmTable.DTO.Table<string>[],
+		oDataString: string,
+	): XrmTable.DTO.Table<string>[] {
+		try {
+			console.log(`Run next query in mock data ${oDataString}`);
+			const astObject = defaultParser.query(oDataString);
+			const astOptions = astObject.value.options ?? [];
+			const selectFields =
+				XrmMockFormODataFilter.getSelectFieldNamesFromAstObject(astOptions);
+			const filterOption =
+				XrmMockFormODataFilter.getFilterFromAstObject(astOptions);
+			if (!filterOption) {
+				if (selectFields.length === 0) {
+					return list;
+				}
+				selectFields.push(`${entityLogicalName}id`);
+				return list.map((x) =>
+					XrmMockFormODataFilter.selectProperties(x, selectFields),
+				);
+			}
+			const filteredItems = list.filter((item) =>
+				XrmMockFormODataFilter.filterListItem(item, filterOption),
+			);
+			if (selectFields.length === 0) {
+				return filteredItems;
+			}
+			selectFields.push(`${entityLogicalName}id`);
+			return filteredItems.map((x) =>
+				XrmMockFormODataFilter.selectProperties(x, selectFields),
+			);
+		} catch (error) {
+			console.error(`Failed to parse the OData query ${error}`);
+			return list;
+		}
+	}
 
-    /**
-     * Given an Item provide the
-     * @param item Table item into which we will apply the oData select
-     * @param oDataString oDataString with the select expression to apply to the table
-     * @returns
-     */
-    public static executeSelectSingleRecord(item: XrmTable.DTO.Table<string>, oDataString?: string): XrmTable.DTO.Table<string> {
-        if (!oDataString) {
-            // if no select return just the whole item
-            return item;
-        }
-        const ast = defaultParser.query(oDataString);
-        const astOptions = ast.value.options ?? [];
-        const selectFields = XrmMockFormODataFilter.getSelectFieldNamesFromAstObject(astOptions);
-        return XrmMockFormODataFilter.selectProperties(item, selectFields);
-    }
+	/**
+	 * Given an Item provide the
+	 * @param item Table item into which we will apply the oData select
+	 * @param oDataString oDataString with the select expression to apply to the table
+	 * @returns
+	 */
+	public static executeSelectSingleRecord(
+		item: XrmTable.DTO.Table<string>,
+		oDataString?: string,
+	): XrmTable.DTO.Table<string> {
+		if (!oDataString) {
+			// if no select return just the whole item
+			return item;
+		}
+		const ast = defaultParser.query(oDataString);
+		const astOptions = ast.value.options ?? [];
+		const selectFields =
+			XrmMockFormODataFilter.getSelectFieldNamesFromAstObject(astOptions);
+		return XrmMockFormODataFilter.selectProperties(item, selectFields);
+	}
 
-    private static getSelectFieldNamesFromAstObject(astOptions: Token[]): string[] {
-        const selectFieldsToken: Token[] = astOptions.find((opt) => opt.type === TokenType.Select)?.value?.items ?? [];
-        return selectFieldsToken.map((x) => x.raw);
-    }
+	private static getSelectFieldNamesFromAstObject(
+		astOptions: Token[],
+	): string[] {
+		const selectFieldsToken: Token[] =
+			astOptions.find((opt) => opt.type === TokenType.Select)?.value?.items ??
+			[];
+		return selectFieldsToken.map((x) => x.raw);
+	}
 
-    private static getFilterFromAstObject(astOptions: Token[]): Token | null {
-        return astOptions.find((opt) => opt.type === TokenType.Filter) ?? null;
-    }
+	private static getFilterFromAstObject(astOptions: Token[]): Token | null {
+		return astOptions.find((opt) => opt.type === TokenType.Filter) ?? null;
+	}
 
-    private static selectProperties(listItem: XrmTable.DTO.Table<string>, returnKeys: string[]): XrmTable.DTO.Table<string> {
-        const result: XrmTable.DTO.Table<string> = {};
-        returnKeys.forEach((fieldName) => {
-            if (XrmMockFormODataFilter.isFieldNodeStartAndEndWithLimiters(fieldName, "_", "_value")) {
-                const dtoFieldName = XrmMockFormODataFilter.deleteRawNodeStartAndEnd(fieldName, "_", "_value");
-                const formattedFieldName = `${fieldName}@OData.Community.Display.V1.FormattedValue`;
-                const formattedDtoFieldName = `${dtoFieldName}_name_`;
-                result[fieldName] = listItem[dtoFieldName];
-                if (listItem[formattedDtoFieldName]) {
-                    result[formattedFieldName] = listItem[formattedDtoFieldName];
-                } else if (result[fieldName]) {
-                    result[formattedFieldName] = `name_${result[fieldName]}`;
-                }
-            } else {
-                result[fieldName] = listItem[fieldName];
-            }
-        });
-        return result;
-    }
+	private static selectProperties(
+		listItem: XrmTable.DTO.Table<string>,
+		returnKeys: string[],
+	): XrmTable.DTO.Table<string> {
+		const result: XrmTable.DTO.Table<string> = {};
+		returnKeys.forEach((fieldName) => {
+			if (
+				XrmMockFormODataFilter.isFieldNodeStartAndEndWithLimiters(
+					fieldName,
+					"_",
+					"_value",
+				)
+			) {
+				const dtoFieldName = XrmMockFormODataFilter.deleteRawNodeStartAndEnd(
+					fieldName,
+					"_",
+					"_value",
+				);
+				const formattedFieldName = `${fieldName}@OData.Community.Display.V1.FormattedValue`;
+				const formattedDtoFieldName = `${dtoFieldName}_name_`;
+				result[fieldName] = listItem[dtoFieldName];
+				if (listItem[formattedDtoFieldName]) {
+					result[formattedFieldName] = listItem[formattedDtoFieldName];
+				} else if (result[fieldName]) {
+					result[formattedFieldName] = `name_${result[fieldName]}`;
+				}
+			} else {
+				result[fieldName] = listItem[fieldName];
+			}
+		});
+		return result;
+	}
 
-    private static filterListItem(item: XrmTable.DTO.Table<string>, filterQueryAst: Token): boolean {
-        return XrmMockFormODataFilter.evaluate(item, filterQueryAst.value);
-    }
+	private static filterListItem(
+		item: XrmTable.DTO.Table<string>,
+		filterQueryAst: Token,
+	): boolean {
+		return XrmMockFormODataFilter.evaluate(item, filterQueryAst.value);
+	}
 
-    private static evaluate(item: XrmTable.DTO.Table<string>, node: Token): boolean {
-        switch (node.type) {
-            case TokenType.AndExpression:
-                return XrmMockFormODataFilter.evaluate(item, node.value.left) && XrmMockFormODataFilter.evaluate(item, node.value.right);
-            case TokenType.OrExpression:
-                return XrmMockFormODataFilter.evaluate(item, node.value.left) || XrmMockFormODataFilter.evaluate(item, node.value.right);
-            case TokenType.NotExpression:
-                return !XrmMockFormODataFilter.evaluate(item, node.value);
-            case TokenType.EqualsExpression:
-            case TokenType.NotEqualsExpression:
-            case TokenType.GreaterThanExpression:
-            case TokenType.GreaterOrEqualsExpression:
-            case TokenType.LesserThanExpression:
-            case TokenType.LesserOrEqualsExpression:
-                return XrmMockFormODataFilter.ops[node.type](
-                    XrmMockFormODataFilter.resolveValue(item, node.value.left),
-                    XrmMockFormODataFilter.resolveValue(item, node.value.right)
-                );
-            case TokenType.MethodCallExpression:
-                return XrmMockFormODataFilter.handleFunction(item, node);
+	private static evaluate(
+		item: XrmTable.DTO.Table<string>,
+		node: Token,
+	): boolean {
+		switch (node.type) {
+			case TokenType.AndExpression:
+				return (
+					XrmMockFormODataFilter.evaluate(item, node.value.left) &&
+					XrmMockFormODataFilter.evaluate(item, node.value.right)
+				);
+			case TokenType.OrExpression:
+				return (
+					XrmMockFormODataFilter.evaluate(item, node.value.left) ||
+					XrmMockFormODataFilter.evaluate(item, node.value.right)
+				);
+			case TokenType.NotExpression:
+				return !XrmMockFormODataFilter.evaluate(item, node.value);
+			case TokenType.EqualsExpression:
+			case TokenType.NotEqualsExpression:
+			case TokenType.GreaterThanExpression:
+			case TokenType.GreaterOrEqualsExpression:
+			case TokenType.LesserThanExpression:
+			case TokenType.LesserOrEqualsExpression:
+				return XrmMockFormODataFilter.ops[node.type](
+					XrmMockFormODataFilter.resolveValue(item, node.value.left),
+					XrmMockFormODataFilter.resolveValue(item, node.value.right),
+				);
+			case TokenType.MethodCallExpression:
+				return XrmMockFormODataFilter.handleFunction(item, node);
 
-            default:
-                return true;
-        }
-    }
+			default:
+				return true;
+		}
+	}
 
-    private static resolveValue(item: XrmTable.DTO.Table<string>, node: Token): TokenValue {
-        // assumption all expression have fields as first value in the expression
-        if (node.type === TokenType.FirstMemberExpression) {
-            const fieldName = XrmMockFormODataFilter.convertNodeToFieldName(node);
-            if (typeof fieldName === "string" && item[fieldName] !== undefined) {
-                return item[fieldName];
-            }
-        }
-        if (node.raw == "null") {
-            return null;
-        }
-        if (node.type == TokenType.Literal && typeof node.raw === "string" && node.value === "Edm.Int32") {
-            return Number.parseInt(node.raw, 10);
-        }
-        if (node.type == TokenType.Literal && typeof node.raw === "string") {
-            return XrmMockFormODataFilter.deleteRawNodeStartAndEnd(node.raw, "'", "'");
-        }
-        return node.raw;
-    }
+	private static resolveValue(
+		item: XrmTable.DTO.Table<string>,
+		node: Token,
+	): TokenValue {
+		// assumption all expression have fields as first value in the expression
+		if (node.type === TokenType.FirstMemberExpression) {
+			const fieldName = XrmMockFormODataFilter.convertNodeToFieldName(node);
+			if (typeof fieldName === "string" && item[fieldName] !== undefined) {
+				return item[fieldName];
+			}
+		}
+		if (node.raw == "null") {
+			return null;
+		}
+		if (
+			node.type == TokenType.Literal &&
+			typeof node.raw === "string" &&
+			node.value === "Edm.Int32"
+		) {
+			return Number.parseInt(node.raw, 10);
+		}
+		if (node.type == TokenType.Literal && typeof node.raw === "string") {
+			return XrmMockFormODataFilter.deleteRawNodeStartAndEnd(
+				node.raw,
+				"'",
+				"'",
+			);
+		}
+		return node.raw;
+	}
 
-    private static convertNodeToFieldName(node: Token): TokenValue {
-        if (typeof node.raw === "string") {
-            return XrmMockFormODataFilter.deleteRawNodeStartAndEnd(node.raw, "_", "_value");
-        }
-        return node.raw;
-    }
+	private static convertNodeToFieldName(node: Token): TokenValue {
+		if (typeof node.raw === "string") {
+			return XrmMockFormODataFilter.deleteRawNodeStartAndEnd(
+				node.raw,
+				"_",
+				"_value",
+			);
+		}
+		return node.raw;
+	}
 
-    private static deleteRawNodeStartAndEnd(nodeRaw: string, startLimiter: string, endLimiter: string): string {
-        if (XrmMockFormODataFilter.isFieldNodeStartAndEndWithLimiters(nodeRaw, startLimiter, endLimiter)) {
-            return nodeRaw.substring(nodeRaw.indexOf(startLimiter) + 1, nodeRaw.lastIndexOf(endLimiter));
-        }
-        return nodeRaw;
-    }
+	private static deleteRawNodeStartAndEnd(
+		nodeRaw: string,
+		startLimiter: string,
+		endLimiter: string,
+	): string {
+		if (
+			XrmMockFormODataFilter.isFieldNodeStartAndEndWithLimiters(
+				nodeRaw,
+				startLimiter,
+				endLimiter,
+			)
+		) {
+			return nodeRaw.substring(
+				nodeRaw.indexOf(startLimiter) + 1,
+				nodeRaw.lastIndexOf(endLimiter),
+			);
+		}
+		return nodeRaw;
+	}
 
-    private static isFieldNodeStartAndEndWithLimiters(nodeRaw: string, startLimiter: string, endLimiter: string): boolean {
-        return nodeRaw.startsWith(startLimiter) && nodeRaw.endsWith(endLimiter);
-    }
+	private static isFieldNodeStartAndEndWithLimiters(
+		nodeRaw: string,
+		startLimiter: string,
+		endLimiter: string,
+	): boolean {
+		return nodeRaw.startsWith(startLimiter) && nodeRaw.endsWith(endLimiter);
+	}
 
-    private static handleFunction(item: XrmTable.DTO.Table<string>, node: Token): boolean {
-        // Resolve arguments (e.g., the property value and the literal string)
-        if (!!node.value.parameters && node.value.parameters.length > 1) {
-            const fieldName: string | null = node.value?.parameters?.[0]?.raw ?? null;
-            const fieldValue: string | null = node.value?.parameters?.[1]?.raw ?? null;
-            const operator = node.value.method;
-            if (fieldName && fieldValue) {
-                const target = item[fieldName];
-                switch (operator) {
-                    case "contains":
-                        return target?.toLocaleString().includes(fieldValue) ?? false;
-                    case "startswith":
-                        return target?.toLocaleString().startsWith(fieldValue) ?? false;
-                    case "endswith":
-                        return target?.toLocaleString().endsWith(fieldValue) ?? false;
-                    default:
-                        return false;
-                }
-            }
-        }
-        return false;
-    }
+	private static handleFunction(
+		item: XrmTable.DTO.Table<string>,
+		node: Token,
+	): boolean {
+		// Resolve arguments (e.g., the property value and the literal string)
+		if (!!node.value.parameters && node.value.parameters.length > 1) {
+			const fieldName: string | null = node.value?.parameters?.[0]?.raw ?? null;
+			const fieldValue: string | null =
+				node.value?.parameters?.[1]?.raw ?? null;
+			const operator = node.value.method;
+			if (fieldName && fieldValue) {
+				const target = item[fieldName];
+				switch (operator) {
+					case "contains":
+						return target?.toLocaleString().includes(fieldValue) ?? false;
+					case "startswith":
+						return target?.toLocaleString().startsWith(fieldValue) ?? false;
+					case "endswith":
+						return target?.toLocaleString().endsWith(fieldValue) ?? false;
+					default:
+						return false;
+				}
+			}
+		}
+		return false;
+	}
 }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_test_context_builder.ts
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_test_context_builder.ts
@@ -1,1589 +1,1948 @@
 import {
-    BooleanAttributeMock,
-    BooleanControlMock,
-    DateAttributeMock,
-    DateControlMock,
-    EntityMock,
-    EventContextMock,
-    FormItemMock,
-    IEntityComponents,
-    ItemCollectionMock,
-    LookupAttributeMock,
-    LookupControlMock,
-    NumberAttributeMock,
-    NumberControlMock,
-    OptionSetAttributeMock,
-    OptionSetControlMock,
-    StringAttributeMock,
-    StringControlMock,
-    TabMock,
-    XrmMockGenerator,
-    GridControlMock,
-    DataMock,
-    GridMock,
-    GridEntityMock,
-    GridRowDataMock,
-    GridRowMock,
-    ContextMock,
-    FormSelectorMock,
+	BooleanAttributeMock,
+	BooleanControlMock,
+	DateAttributeMock,
+	DateControlMock,
+	EntityMock,
+	EventContextMock,
+	FormItemMock,
+	IEntityComponents,
+	ItemCollectionMock,
+	LookupAttributeMock,
+	LookupControlMock,
+	NumberAttributeMock,
+	NumberControlMock,
+	OptionSetAttributeMock,
+	OptionSetControlMock,
+	StringAttributeMock,
+	StringControlMock,
+	TabMock,
+	XrmMockGenerator,
+	GridControlMock,
+	DataMock,
+	GridMock,
+	GridEntityMock,
+	GridRowDataMock,
+	GridRowMock,
+	ContextMock,
+	FormSelectorMock,
 } from "xrm-mock";
 import { EventContextWithEventArgsMock } from "xrm-mock/dist/xrm-mock/events/eventcontextwitheventargs.mock";
 import {
-    IXrmMockFormTestContextBuilder,
-    XrmFormAttributeMethodMockStubs,
-    XrmConsoleMockStubs,
-    XrmCustomApiMockData,
-    XrmFormContextDataMockStubs,
-    XrmFormMockAttributeControlUpdateBase,
-    XrmFormMockServerData,
-    XrmFormTabUpdateData,
-    XrmMockAttributeType,
-    XrmMockConfirmDialogResponses,
-    XrmMockControlType,
-    XrmFormContextUiMockStubs,
-    XrmNavigationMockStubs,
-    XrmSubGridControlMockStubs,
-    XrmFormContextTabEventsStub,
-    XrmUtilityApiMockStubs,
-    XrmWebApiMockStubs,
-    XrmWebApiOnlineMockStubs,
-    XrmSubGridRowMocks,
-    XrmFormGridMockRowConfig,
-    XrmFormGridMockRowConfigRow,
-    XrmFormSubGridAttributeUpdateValue,
-    XrmLookupControlMockStubs,
-    XrmFormTabUpdateBase,
-    XrmStandardControlMockStubs,
-    XrmFormMockFormItem,
-    XrmFormSelectorMockStubs,
-    XrmOptionSetControlMockStubs,
+	IXrmMockFormTestContextBuilder,
+	XrmFormAttributeMethodMockStubs,
+	XrmConsoleMockStubs,
+	XrmCustomApiMockData,
+	XrmFormContextDataMockStubs,
+	XrmFormMockAttributeControlUpdateBase,
+	XrmFormMockServerData,
+	XrmFormTabUpdateData,
+	XrmMockAttributeType,
+	XrmMockConfirmDialogResponses,
+	XrmMockControlType,
+	XrmFormContextUiMockStubs,
+	XrmNavigationMockStubs,
+	XrmSubGridControlMockStubs,
+	XrmFormContextTabEventsStub,
+	XrmUtilityApiMockStubs,
+	XrmWebApiMockStubs,
+	XrmWebApiOnlineMockStubs,
+	XrmSubGridRowMocks,
+	XrmFormGridMockRowConfig,
+	XrmFormGridMockRowConfigRow,
+	XrmFormSubGridAttributeUpdateValue,
+	XrmLookupControlMockStubs,
+	XrmFormTabUpdateBase,
+	XrmStandardControlMockStubs,
+	XrmFormMockFormItem,
+	XrmFormSelectorMockStubs,
+	XrmOptionSetControlMockStubs,
 } from "./xrm_mock_form_test_context_types";
 import { XrmMockFormODataFilter } from "./xrm_mock_form_odata_filter";
 import Context from "xrm-mock/dist/xrm-mock-generator/context";
 
 /** Auxiliary class for simplified xrm-mock testing */
 export class XrmMockFormTestContextBuilder<
-    TTabNames extends string,
-    TSectionNames extends string,
-    TControlName extends string,
-    TAttributeNames extends string,
-> implements IXrmMockFormTestContextBuilder<TTabNames, TSectionNames, TControlName, TAttributeNames> {
-    public static readonly ERROR_NO_CUSTOM_API = "Bad Request";
-    public xrmWebApiMockStubs: XrmWebApiMockStubs = {};
-    public xrmWebApiOnlineMockStubs: XrmWebApiOnlineMockStubs = {};
-    public xrmNavigationMockStubs: XrmNavigationMockStubs = {};
-    public xrmUiFormMocksStubs: XrmFormContextUiMockStubs = {};
-    public xrmUtilityApiMockStubs: XrmUtilityApiMockStubs = {};
-    public xrmFormAttributeMethodMockStubs: XrmFormAttributeMethodMockStubs<TAttributeNames> = {};
-    public xrmSubGridControlMockStubs: XrmSubGridControlMockStubs<TControlName> = {};
-    public xrmFormSelectorMockStub: XrmFormSelectorMockStubs = {};
-    public xrmStandardControlMockStubs: XrmStandardControlMockStubs<TControlName> = {};
-    public xrmOptionSetControlMockStubs: XrmOptionSetControlMockStubs<TControlName> = {};
-    public xrmLookupControlMockStubs: XrmLookupControlMockStubs<TControlName> = {};
-    public xrmTabEventsStub: XrmFormContextTabEventsStub<TTabNames> = {};
-    public xrmFormDataMockStubs: XrmFormContextDataMockStubs = {};
-    public xrmConsoleMockStubs: XrmConsoleMockStubs = {};
-    public xrmFetchMockStubs: jest.Mock | null = null;
-    public xrmPreSaveEvent: jest.Mock | null = null;
-    public formEntity: IEntityComponents = {};
-
-    private readonly xrmSubGridConfig: Map<TControlName, XrmFormGridMockRowConfig<string>> = new Map<
-        TControlName,
-        XrmFormGridMockRowConfig<string>
-    >();
-    private readonly xrmSubGridRowMocks: Map<TControlName, XrmSubGridRowMocks> = new Map<TControlName, XrmSubGridRowMocks>();
-    private formType: XrmEnum.FormType = XrmEnum.FormType.Create; //default value
-    private confirmDialogConfirmedSeq: XrmMockConfirmDialogResponses[] = [];
-    private isMockAttributeChanges: boolean = false;
-    private isSubGridMethodsMock: boolean = false;
-    private isControlMethodMock: boolean = false;
-    private isMockTabEvents: boolean = false;
-    private isMockPreSaveEvent: boolean = false;
-    private isMockFormDateEvent: boolean = false;
-    private isMockFormUiEvent: boolean = false;
-    private isFormDataValid: boolean = false;
-    private isFormDataDirty: boolean = false;
-    private isConsoleMocked: boolean = false;
-    private isControlLookupMethodMock: boolean = false;
-    private saveErrorMessage: string | null = null;
-    private refreshErrorMessage: string | null = null;
-    private userRoles: Xrm.LookupValue[] = [];
-    private languageId: number = 1033;
-    private clientUrl: string | null = null;
-    private formSelectorItems: XrmFormMockFormItem[] = [];
-    private retrieveServerMockDateError: string | null = null;
-    private updateServerMockDateError: string | null = null;
-    private readonly mockAttributes: Map<TAttributeNames, XrmMockAttributeType>;
-    private readonly mockControls: Map<TControlName, XrmMockControlType>;
-    private readonly controlConfig: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>[];
-    private readonly attributeConfig: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>[];
-    private readonly tabConfig: XrmForm.Tester.XrmFormMockTab<TTabNames, TSectionNames, TControlName>[];
-    private readonly serverMockData: XrmFormMockServerData = {};
-    private readonly serverCustomApiMockData: XrmCustomApiMockData = {};
-    private readonly serverCustomApiExceptions: Map<string, string>;
-
-    /**
-     * @summary Default constructor function
-     * @param initialControlsConfig Configuration for control names/ types / status and related attributes
-     * @param initialAttributesConfig Configuration for attribute names/ types / values, required level
-     * @param initialTabsConfig Configuration for tab/section/controls
-     */
-    constructor(
-        initialControlsConfig: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>[],
-        initialAttributesConfig: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>[],
-        initialTabsConfig: XrmForm.Tester.XrmFormMockTab<TTabNames, TSectionNames, TControlName>[]
-    ) {
-        // Gets inputs from the generated files with the form description
-        this.mockAttributes = new Map<TAttributeNames, XrmMockAttributeType>();
-        this.mockControls = new Map<TControlName, XrmMockControlType>();
-        this.serverCustomApiExceptions = new Map<string, string>();
-        this.controlConfig = initialControlsConfig.map((item) => ({ ...item }));
-        this.attributeConfig = initialAttributesConfig.map((item) => ({
-            ...item,
-            options: item.options?.map((opt) => ({ ...opt })),
-            value: {
-                ...item.value,
-                valueLookup: item.value?.valueLookup ? item.value.valueLookup.map((valueLookup) => ({ ...valueLookup })) : undefined,
-                valueNumberMset: item.value?.valueNumberMset ? item.value.valueNumberMset.map((valueNumber) => valueNumber) : undefined,
-            },
-        }));
-        this.tabConfig = initialTabsConfig.map((item) => ({
-            ...item,
-            sections: item.sections.map((section) => ({ ...section, controlNames: section.controlNames.map((x) => x) })),
-        }));
-        this.formEntity = {
-            id: crypto.randomUUID(),
-            entityName: "defaultEntity",
-        };
-    }
-    /**
-     * @summary Simple function to get the correctly mapped load event with arguments to pass to form load
-     * @returns the mock load event to be passed to the onload form event
-     */
-    public getLoadExecutionContext(): EventContextWithEventArgsMock<Xrm.Events.LoadEventArguments> {
-        const eventContext = XrmMockGenerator.getEventContext() ?? new EventContextMock({});
-        const eventArgs: Xrm.Events.LoadEventArguments = {
-            getDataLoadState: () => XrmEnum.FormDataLoadState.InitialLoad,
-        };
-
-        return new EventContextWithEventArgsMock<Xrm.Events.LoadEventArguments>({
-            context: eventContext.context,
-            depth: eventContext.depth,
-            eventArgs: eventArgs,
-            eventSource: eventContext.eventSource,
-            formContext: eventContext.formContext,
-            sharedVariables: eventContext.sharedVariables,
-        });
-    }
-
-    /**
-     * Get mock form context with specific provided type
-     * @returns
-     */
-    public getMockFormContext<T extends Xrm.FormContext>(): T {
-        return <T>this.getLoadExecutionContext().getFormContext();
-    }
-
-    /**
-     * Generate an form even execution context with a input control source event
-     * @param source
-     * @returns
-     */
-    public getExecutionContextWithSource(
-        source: Xrm.Attributes.Attribute | Xrm.Controls.Control | Xrm.Controls.Tab | Xrm.Entity
-    ): EventContextWithEventArgsMock<Xrm.Events.EventContext> {
-        const eventContext = XrmMockGenerator.getEventContext() ?? new EventContextMock({});
-        return new EventContextWithEventArgsMock<Xrm.Events.EventContext>({
-            context: eventContext.context,
-            depth: eventContext.depth,
-            eventSource: source as unknown as Xrm.Attributes.Attribute | Xrm.Controls.Control | Xrm.Entity,
-            formContext: eventContext.formContext,
-            sharedVariables: eventContext.sharedVariables,
-        });
-    }
-
-    /**
-     * Generate a form asyn event context
-     * @param source
-     * @returns
-     */
-    public getSaveAsyncEventContext(): EventContextWithEventArgsMock<Xrm.Events.SaveEventArgumentsAsync> {
-        const eventContext = XrmMockGenerator.getEventContext() ?? new EventContextMock({});
-        const eventArgs: Xrm.Events.SaveEventArgumentsAsync = {
-            disableAsyncTimeout: jest.fn(),
-            getSaveMode: jest.fn(),
-            isDefaultPrevented: jest.fn(),
-            preventDefault: jest.fn(),
-            preventDefaultOnError: jest.fn(),
-        };
-        return new EventContextWithEventArgsMock<Xrm.Events.SaveEventArgumentsAsync>({
-            context: eventContext.context,
-            depth: eventContext.depth,
-            formContext: eventContext.formContext,
-            sharedVariables: eventContext.sharedVariables,
-            eventArgs: eventArgs,
-        });
-    }
-
-    /**
-     * Given the form context config and data it generates the xrm-mock form, needs to be called before the test starts
-     * @returns The object itself
-     */
-    public buildMockFormContext(): this {
-        XrmMockGenerator.initialise({
-            context: this.MapFormContext(),
-            entity: this.formEntity,
-            process: undefined,
-        });
-
-        // If sub grid mock config, then init subGrid row mocks before controls as controls mocks use it
-        if (this.isSubGridMethodsMock && this.xrmSubGridConfig.size > 0) {
-            this.InitSubGridConfigMockRows();
-        }
-        this.InitializeMockFormContextControls();
-        this.InitTabs();
-        this.InitXrmNavigationApiMocks();
-        this.InitXrmUtilityMocks();
-        this.InitFormUiSelector();
-
-        if (this.isMockFormDateEvent) {
-            this.InitMockFormDataEvent();
-        }
-        if (this.isMockFormUiEvent) {
-            this.InitFormUiMocks();
-        }
-        if (this.serverMockData) {
-            this.InitXrmWebApiServerMocks();
-        }
-        if (this.serverCustomApiMockData || this.serverCustomApiExceptions.size > 0) {
-            this.InitXrmWebApiOnlineMocks();
-        }
-        if (this.isMockPreSaveEvent) {
-            this.InitPreSaveMock();
-        }
-        if (this.isConsoleMocked) {
-            this.InitConsoleMock();
-        }
-        return this;
-    }
-
-    /**
-     * Modifies the default form context config with the given update data
-     * @param updateData Simply array with the control/attributes to be changed
-     * @returns the object itself
-     */
-    public withFormAttributeControlData(updateData: XrmFormMockAttributeControlUpdateBase<TControlName, TAttributeNames>[]): this {
-        this.UpdateControlConfig(updateData);
-        return this;
-    }
-
-    /**
-     * Set the entity id with update form data
-     * @param updateData
-     * @returns
-     */
-    public withFormTabData(updateData: XrmFormTabUpdateData<TTabNames, TSectionNames>): this {
-        this.UpdateTabConfig(updateData);
-        return this;
-    }
-
-    /***
-     * Set the entity id of the form so it is returned when calling entity.GetId()
-     * @param recordId unique id of the form entity
-     */
-    public withEntity(entityName: string, entityId: string): this {
-        this.formEntity = {
-            entityName,
-            id: entityId,
-        };
-        return this;
-    }
-
-    /**
-     * To set the form type on creation
-     * @param formType Form type of the form context
-     * @returns
-     */
-    public withFormType(formType: XrmEnum.FormType): this {
-        this.formType = formType;
-        return this;
-    }
-
-    /**
-     * Setup a fake server data to be returned by the sino stubs
-     * @param data Simple array of entity lists to be a fake for stubs to return
-     */
-    public withServerData(data: XrmFormMockServerData): this {
-        Object.assign(this.serverMockData, data);
-        return this;
-    }
-
-    /**
-     * With error message when calling server retrieve
-     * @param erroMsg
-     * @returns
-     */
-    public withRetrieveServerDataError(erroMsg: string): this {
-        this.retrieveServerMockDateError = erroMsg;
-        return this;
-    }
-
-    /**
-     * With error message when calling server update
-     * @param erroMsg
-     * @returns
-     */
-    public withUpdateServerDateErrorMessage(erroMsg: string): this {
-        this.updateServerMockDateError = erroMsg;
-        return this;
-    }
-
-    /**
-     * Configure a list of custom api mock data that the test context builder will contain
-     * @param data Object containing a map of custom api names and the mock responses
-     * @returns
-     */
-    public withCustomApis(data: XrmCustomApiMockData): this {
-        Object.assign(this.serverCustomApiMockData, data);
-        return this;
-    }
-
-    /**
-     * Configure a single custom api with name + response
-     * @param name
-     * @param response
-     * @returns
-     */
-    public withCustomApi<T extends XrmWebApi.ExecuteResponse>(name: string, response: T): this {
-        this.serverCustomApiMockData[name] = response;
-        return this;
-    }
-
-    /**
-     * Configure single custom api to return exception for unhandled exception catch handling
-     * @param name
-     * @param errorMsg
-     */
-    public withCustomApiException(name: string, errorMsg: string): this {
-        this.serverCustomApiExceptions.set(name, errorMsg);
-        return this;
-    }
-
-    /**
-     * Configure the sequence of confirm cancel dialog response for the form context calls
-     * @param confirmDialogConfirmed
-     */
-    public withUserConfirmDialogSeq(confirmDialogConfirmed: boolean[]): this {
-        this.confirmDialogConfirmedSeq = confirmDialogConfirmed.map((x) => ({ confirmed: x, executed: false }));
-        return this;
-    }
-
-    /**
-     * Configure if we need a jest attribute mock changes
-     * @param isMockAttributeChanges
-     * @returns
-     */
-    public withAttributeMockChange(isMockAttributeChanges: boolean): this {
-        this.isMockAttributeChanges = isMockAttributeChanges;
-        return this;
-    }
-
-    /**
-     * Configure if you want to jest mock sub grid mock loads
-     * @param isSubGridLoad
-     * @returns
-     */
-    public withSubGridMethodsMock(isSubGridLoad: boolean): this {
-        this.isSubGridMethodsMock = isSubGridLoad;
-        return this;
-    }
-
-    /**
-     * Control if you want to jest mock control mocks
-     * @param isControlMethodMock
-     * @returns
-     */
-    public WithControlMethodMock(isControlMethodMock: boolean): this {
-        this.isControlMethodMock = isControlMethodMock;
-        return this;
-    }
-
-    /**
-     * Configure if you want to jest mock tab events
-     * @param isMockTabEvents
-     * @returns
-     */
-    public withRegisterTabEventsMocks(isMockTabEvents: boolean): this {
-        this.isMockTabEvents = isMockTabEvents;
-        return this;
-    }
-
-    /**
-     * Configure is you want to jest mock save events
-     * @param isPreSaveEventMock
-     * @returns
-     */
-    public withPreSaveEventMock(isPreSaveEventMock: boolean): this {
-        this.isMockPreSaveEvent = isPreSaveEventMock;
-        return this;
-    }
-
-    /**
-     * Set form context language id to be returned by the getGlobalContext
-     * @param languageId
-     * @returns
-     */
-    public withLanguageId(languageId: number): this {
-        this.languageId = languageId;
-        return this;
-    }
-
-    /**
-     * Set form context client url
-     * @param clientUrl
-     * @returns
-     */
-    public withClientUrl(clientUrl: string): this {
-        this.clientUrl = clientUrl;
-        return this;
-    }
-
-    /**
-     * Set form context user roles to be returned by the getGlobalContext
-     * @param roles
-     * @returns
-     */
-    public withUserRoles(roles: Xrm.LookupValue[]): this {
-        this.userRoles = roles;
-        return this;
-    }
-
-    /**
-     * Configure if you want to jest mock form data events
-     * @param isMockFormDateEventMock
-     * @returns
-     */
-    public withFormDataEventMock(isMockFormDateEventMock: boolean): this {
-        this.isMockFormDateEvent = isMockFormDateEventMock;
-        return this;
-    }
-
-    /**
-     * Configure if you want to jest mock form ui events
-     * @param isMockFormUiEvent
-     * @returns
-     */
-    public withFormUiEventMock(isMockFormUiEvent: boolean): this {
-        this.isMockFormUiEvent = isMockFormUiEvent;
-        return this;
-    }
-
-    /**
-     * Configure if form data valid mock returns specific value
-     * @param isValid
-     * @returns
-     */
-    public withFormDataValid(isValid: boolean): this {
-        this.isFormDataValid = isValid;
-        return this;
-    }
-
-    /**
-     * Configure if form data valid mock returns specific value
-     * @param isDirty
-     * @returns
-     */
-    public withFormDataDirty(isDirty: boolean): this {
-        this.isFormDataDirty = isDirty;
-        return this;
-    }
-
-    /**
-     * Configure so form data save returns an error message
-     * @param isDirty
-     * @returns
-     */
-    public withSaveErrorMessage(errorMsg: string | null): this {
-        this.saveErrorMessage = errorMsg;
-        return this;
-    }
-
-    /**
-     * Configure form data refresh returns an error message
-     * @param errorMsg 
-     * @returns 
-     */
-    public withRefreshErrorMessage(errorMsg: string | null): this {
-        this.refreshErrorMessage = errorMsg;
-        return this;
-    }
-
-    /**
-     * Configure a console log mock to assertions on to of console statements
-     * @param isConsoleMocked
-     * @returns
-     */
-    public withConsoleMocked(isConsoleMocked: boolean): this {
-        this.isConsoleMocked = isConsoleMocked;
-        return this;
-    }
-
-    /**
-     * Add a mock for a simple fetch with a certain response
-     * @param statusCode
-     * @param response
-     */
-    public withFetchResponse(statusCode: number, response: string): this {
-        this.xrmFetchMockStubs = jest.fn((_url: URL | RequestInfo): Promise<Response> => {
-            const isOK = statusCode >= 200 && statusCode <= 299;
-            return Promise.resolve(
-                new Response(response, {
-                    status: statusCode,
-                    statusText: isOK ? "OK" : "Internal Error",
-                })
-            );
-        });
-        globalThis.fetch = this.xrmFetchMockStubs;
-        return this;
-    }
-
-    /**
-     * Add a mock for a simple fetch with a certain response
-     * @param statusCode
-     * @param response
-     */
-    public withFetchException(errorMsg: string): this {
-        this.xrmFetchMockStubs = jest.fn((_url: URL | RequestInfo): Promise<Response> => {
-            throw new Error(errorMsg);
-        });
-        globalThis.fetch = this.xrmFetchMockStubs;
-        return this;
-    }
-
-    /**
-     * Configure sub grid mocks to be able to interact with the sub grid rows attributes
-     * @param name
-     * @param updateGridRows
-     * @returns
-     */
-    public withSubGridMockRows<TGridAttributeNames extends string>(
-        name: TControlName,
-        updateGridRows: XrmFormGridMockRowConfig<TGridAttributeNames>
-    ): this {
-        if (!updateGridRows.selectedRowsIndexes.every((index) => index >= 0 && index < updateGridRows.gridRows.length)) {
-            throw new Error("Wrong input selectedRowsIndexes value over length of rows");
-        }
-        this.xrmSubGridConfig.set(name, {
-            ...updateGridRows,
-            subGridRowsAttributeConfig: updateGridRows.subGridRowsAttributeConfig.map((item) => ({
-                ...item,
-                options: item.options?.map((opt) => ({ ...opt })),
-                value: {
-                    ...item.value,
-                    valueLookup: item.value?.valueLookup ? item.value.valueLookup.map((valueLookup) => ({ ...valueLookup })) : undefined,
-                    valueNumberMset: item.value?.valueNumberMset ? item.value.valueNumberMset.map((valueNumber) => valueNumber) : undefined,
-                },
-            })),
-        });
-        return this;
-    }
-
-    /**
-     * Configure if form mocks the control lookup methods
-     * @param name
-     * @param updateGridRows
-     * @returns
-     */
-    public withLookupControlMethodEventMock(isLookupControlMock: boolean): this {
-        this.isControlLookupMethodMock = isLookupControlMock;
-        return this;
-    }
-
-    /**
-     * Configure if form mocks contains other form selectors
-     * @param currentForm
-     * @param otherItems
-     * @returns
-     */
-    public withFormSelectorItems(currentForm: XrmFormMockFormItem, otherItems: XrmFormMockFormItem[]): this {
-        this.formSelectorItems = [...otherItems.map((x) => ({ ...x, isCurrent: false })), { ...currentForm, isCurrent: true }];
-        return this;
-    }
-
-    /**
-     * Get mock control in context out of the name string
-     * @param controlName
-     * @returns
-     */
-    public getControl<T extends XrmMockControlType>(controlName: TControlName): T | null {
-        return <T>this.mockControls.get(controlName) ?? null;
-    }
-
-    /**
-     * Get mock attribute in context out of the name string
-     * @param attributeName
-     * @returns
-     */
-    public getAttribute<T extends XrmMockAttributeType>(attributeName: TAttributeNames): T | null {
-        return <T>this.mockAttributes.get(attributeName) ?? null;
-    }
-
-    private InitXrmWebApiServerMocks(): void {
-        this.xrmWebApiMockStubs = {
-            createRecord: jest.fn((entityLogicalName: string, record: XrmTable.DTO.Table<string>): Xrm.Async.PromiseLike<Xrm.CreateResponse> => {
-                return Promise.resolve({
-                    entityType: entityLogicalName,
-                    id: crypto.randomUUID(),
-                }) as unknown as Xrm.Async.PromiseLike<Xrm.CreateResponse>;
-            }),
-            deleteRecord: jest.fn((entityLogicalName: string, id: string): Xrm.Async.PromiseLike<any> => {
-                return Promise.resolve({
-                    entityType: entityLogicalName,
-                    id,
-                    name: "deleteRecordName"
-                }) as unknown as Xrm.Async.PromiseLike<any>;
-            }),
-            retrieveRecord: jest.fn((entityLogicalName: string, id: string, options?: string) =>
-                this.RetrieveSingleStubRecord(entityLogicalName, id, options)
-            ),
-            retrieveMultipleRecords: jest.fn((entityLogicalName: string, options?: string, maxPageSize?: number) =>
-                this.RetrieveMultipleRecords(entityLogicalName, options, maxPageSize)
-            ),
-            updateRecord: jest.fn((entityLogicalName: string, id: string, _data: any) => this.UpdateRecord(entityLogicalName, id)
-            ),
-        };
-        jest.spyOn(Xrm.WebApi, "createRecord").mockImplementation(this.xrmWebApiMockStubs.createRecord);
-        jest.spyOn(Xrm.WebApi, "deleteRecord").mockImplementation(this.xrmWebApiMockStubs.deleteRecord);
-        jest.spyOn(Xrm.WebApi, "retrieveMultipleRecords").mockImplementation(this.xrmWebApiMockStubs.retrieveMultipleRecords);
-        jest.spyOn(Xrm.WebApi, "retrieveRecord").mockImplementation(this.xrmWebApiMockStubs.retrieveRecord);
-        jest.spyOn(Xrm.WebApi, "updateRecord").mockImplementation(this.xrmWebApiMockStubs.updateRecord);
-    }
-
-    private InitXrmWebApiOnlineMocks(): void {
-        this.xrmWebApiOnlineMockStubs = {
-            execute: jest.fn(
-                (request: XrmWebApi.ExecuteRequest): Xrm.Async.PromiseLike<Response> => this.GetCustomApiMockResponse(request)
-            ),
-            executeMultiple: jest.fn(
-                // only empty response from now
-                (request: XrmWebApi.ExecuteRequest[]): Xrm.Async.PromiseLike<Response[]> => Promise.resolve([]) as unknown as Xrm.Async.PromiseLike<Response[]>
-            ),
-        };
-        jest.spyOn(Xrm.WebApi.online, "execute").mockImplementation(this.xrmWebApiOnlineMockStubs.execute);
-    }
-
-    private InitXrmNavigationApiMocks(): void {
-        this.xrmNavigationMockStubs = {
-            navigateTo: jest.fn((_pageInput: | Xrm.Navigation.PageInputEntityRecord
-                | Xrm.Navigation.PageInputEntityList
-                | Xrm.Navigation.CustomPage
-                | Xrm.Navigation.PageInputHtmlWebResource
-                | Xrm.Navigation.Dashboard,
-                _navigationOptions?: Xrm.Navigation.NavigationOptions
-            ) => {
-                return Promise.resolve() as unknown as Xrm.Async.PromiseLike<void>;
-            }),
-            openAlertDialog: jest.fn((_alertStrings: Xrm.Navigation.AlertStrings, _alertOptions?: Xrm.Navigation.DialogSizeOptions) => {
-                return Promise.resolve() as unknown as Xrm.Async.PromiseLike<void>;
-            }),
-            openConfirmDialog: jest.fn(
-                (_confirmString: Xrm.Navigation.ConfirmStrings, confirmOptions?: Xrm.Navigation.DialogSizeOptions) => {
-                    const item = this.confirmDialogConfirmedSeq.find((x) => !x.executed);
-                    if (item) {
-                        item.executed = true;
-                    }
-                    /// no dialog seq provided for this dialog... return false by default
-                    return Promise.resolve({
-                        confirmed: item?.confirmed ?? false,
-                    }) as unknown as Xrm.Async.PromiseLike<Xrm.Navigation.ConfirmResult>;
-                }
-            ),
-            openErrorDialog: jest.fn((_errorOptions: Xrm.Navigation.ErrorDialogOptions) => {
-                return Promise.resolve() as unknown as Xrm.Async.PromiseLike<void>;
-            }),
-            openFile: jest.fn(),
-            openForm: jest.fn(),
-            openUrl: jest.fn(),
-            openWebResource: jest.fn(),
-
-        };
-        jest.spyOn(Xrm.Navigation, "navigateTo").mockImplementation(this.xrmNavigationMockStubs.navigateTo);
-        jest.spyOn(Xrm.Navigation, "openAlertDialog").mockImplementation(this.xrmNavigationMockStubs.openAlertDialog);
-        jest.spyOn(Xrm.Navigation, "openConfirmDialog").mockImplementation(this.xrmNavigationMockStubs.openConfirmDialog);
-        jest.spyOn(Xrm.Navigation, "openErrorDialog").mockImplementation(this.xrmNavigationMockStubs.openErrorDialog);
-        jest.spyOn(Xrm.Navigation, "openFile").mockImplementation(this.xrmNavigationMockStubs.openFile);
-        jest.spyOn(Xrm.Navigation, "openForm").mockImplementation(this.xrmNavigationMockStubs.openForm);
-        jest.spyOn(Xrm.Navigation, "openUrl").mockImplementation(this.xrmNavigationMockStubs.openUrl);
-        jest.spyOn(Xrm.Navigation, "openWebResource").mockImplementation(this.xrmNavigationMockStubs.openWebResource);
-    }
-
-    private InitMockFormDataEvent(): void {
-        this.xrmFormDataMockStubs = {
-            getIsDirty: jest.fn(() => this.isFormDataDirty),
-            isValid: jest.fn(() => this.isFormDataValid),
-            refresh: jest.fn((refresh?: boolean): Xrm.Async.PromiseLike<void> => {
-                if (this.refreshErrorMessage) {
-                    throw new Error(this.refreshErrorMessage);
-                }
-                return Promise.resolve() as unknown as Xrm.Async.PromiseLike<void>;
-            }),
-            save: jest.fn((): Xrm.Async.PromiseLike<void> => {
-                if (this.saveErrorMessage) {
-                    throw new Error(this.saveErrorMessage);
-                }
-                return Promise.resolve() as unknown as Xrm.Async.PromiseLike<void>;
-            }),
-        };
-
-        jest.spyOn(XrmMockGenerator.getFormContext().data, "getIsDirty").mockImplementation(this.xrmFormDataMockStubs.getIsDirty);
-        jest.spyOn(XrmMockGenerator.getFormContext().data, "isValid").mockImplementation(this.xrmFormDataMockStubs.isValid);
-        jest.spyOn(XrmMockGenerator.getFormContext().data, "refresh").mockImplementation(this.xrmFormDataMockStubs.refresh);
-        jest.spyOn(XrmMockGenerator.getFormContext().data, "save").mockImplementation(this.xrmFormDataMockStubs.save);
-    }
-
-    private InitConsoleMock(): void {
-        this.xrmConsoleMockStubs = {
-            log: jest.fn((_message?: any, ..._optionalParams: any[]) => { }),
-            error: jest.fn((_message?: any, ..._optionalParams: any[]) => { }),
-            debug: jest.fn((_message?: any, ..._optionalParams: any[]) => { }),
-        };
-        jest.spyOn(console, "log").mockImplementation(this.xrmConsoleMockStubs.log);
-        jest.spyOn(console, "error").mockImplementation(this.xrmConsoleMockStubs.error);
-        jest.spyOn(console, "debug").mockImplementation(this.xrmConsoleMockStubs.debug);
-    }
-
-    private InitFormUiMocks(): void {
-        this.xrmUiFormMocksStubs = {
-            clearFormNotification: jest.fn((_uniqueId: string): void => { }),
-            close: jest.fn((): void => { }),
-            refreshRibbon: jest.fn((_refreshAll?: boolean): void => { }),
-            setFormNotification: jest.fn((_message: string, _level: Xrm.FormNotificationLevel, _uniqueId: string): boolean => {
-                return true;
-            }),
-        };
-
-        jest.spyOn(XrmMockGenerator.getFormContext().ui, "clearFormNotification").mockImplementation(this.xrmUiFormMocksStubs.clearFormNotification);
-        jest.spyOn(XrmMockGenerator.getFormContext().ui, "close").mockImplementation(this.xrmUiFormMocksStubs.close);
-        jest.spyOn(XrmMockGenerator.getFormContext().ui, "refreshRibbon").mockImplementation(this.xrmUiFormMocksStubs.refreshRibbon);
-        jest.spyOn(XrmMockGenerator.getFormContext().ui, "setFormNotification").mockImplementation(this.xrmUiFormMocksStubs.setFormNotification);
-    }
-
-    private InitXrmUtilityMocks(): void {
-        this.xrmUtilityApiMockStubs = {
-            closeProgressIndicator: jest.fn(),
-            showProgressIndicator: jest.fn(),
-            refreshParentGrid: jest.fn(),
-        };
-        jest.spyOn(Xrm.Utility, "closeProgressIndicator").mockImplementation(this.xrmUtilityApiMockStubs.closeProgressIndicator);
-        jest.spyOn(Xrm.Utility, "showProgressIndicator").mockImplementation(this.xrmUtilityApiMockStubs.showProgressIndicator);
-        jest.spyOn(Xrm.Utility, "refreshParentGrid").mockImplementation(this.xrmUtilityApiMockStubs.refreshParentGrid);
-    }
-
-    private InitFormUiSelector(): void {
-        const currentForm = this.CreateCurrentFormMockItem();
-        const formSelectorMock = XrmMockGenerator.formContext.ui.formSelector as FormSelectorMock;
-        formSelectorMock.items = new ItemCollectionMock<FormItemMock>([currentForm]);
-        for (const otherItem of this.formSelectorItems.filter((x) => !x.isCurrent)) {
-            formSelectorMock.items.push(
-                new FormItemMock({
-                    id: otherItem.id,
-                    label: otherItem.label ?? "",
-                    currentItem: false,
-                    formType: otherItem.formType ?? XrmEnum.FormType.Update,
-                })
-            );
-        }
-        this.AddFormSelectorStubs(formSelectorMock.items.get());
-    }
-
-    private CreateCurrentFormMockItem(): FormItemMock {
-        const currentFormSelector = this.formSelectorItems.find((x) => x.isCurrent);
-        if (currentFormSelector) {
-            // Add with explicitly set data
-            return new FormItemMock({
-                id: currentFormSelector.id,
-                label: currentFormSelector.label ?? "",
-                currentItem: true,
-                formType: currentFormSelector.formType ?? this.formType,
-            });
-        } else {
-            return new FormItemMock({
-                id: "{00000000-0000-0000-0000-000000000000}",
-                label: "current-form",
-                currentItem: true,
-                formType: this.formType,
-            });
-        }
-    }
-
-    private AddFormSelectorStubs(formItemMocks: FormItemMock[]): void {
-        for (const formItemMock of formItemMocks) {
-            const methodMockStub = {
-                navigate: jest.fn(),
-                setVisible: jest.fn((isVisible: boolean): boolean => this.SetFormSelectorItemVisible(isVisible, formItemMock)),
-                getVisible: jest.fn((): boolean => this.GetFormSelectorItemVisible(formItemMock)),
-            };
-            this.xrmFormSelectorMockStub[formItemMock.id] = methodMockStub;
-            formItemMock.navigate = methodMockStub.navigate;
-            formItemMock.setVisible = methodMockStub.setVisible;
-            formItemMock.getVisible = methodMockStub.getVisible;
-        }
-    }
-
-    private GetFormSelectorItemVisible(formItemMock: FormItemMock): boolean {
-        const formItem = this.formSelectorItems.find((x) => x.id === formItemMock.id);
-        if (!formItem) {
-            throw new Error(`Form item with ${formItemMock.id} not found!`);
-        }
-        // if not explicitly set assume visible
-        return formItem.visible ?? true;
-    }
-
-    private SetFormSelectorItemVisible(isVisible: boolean, formItemMock: FormItemMock): boolean {
-        const formItem = this.formSelectorItems.find((x) => x.id === formItemMock.id);
-        if (!formItem) {
-            throw new Error(`Form item with ${formItemMock.id} not found!`);
-        }
-        formItem.visible = isVisible;
-        return true;
-    }
-
-    private RetrieveMultipleRecords(
-        entityLogicalName: string,
-        options?: string,
-        _maxPageSize?: number
-    ): Xrm.Async.PromiseLike<Xrm.RetrieveMultipleResult<XrmTable.DTO.Table<string>>> {
-        if (this.retrieveServerMockDateError) {
-            return Promise.reject(new Error(this.retrieveServerMockDateError)) as unknown as Xrm.Async.PromiseLike<
-                Xrm.RetrieveMultipleResult<XrmTable.DTO.Table<string>>
-            >;
-        }
-        const entityDTOs = this.serverMockData[entityLogicalName];
-        if (!entityDTOs) {
-            return Promise.resolve({
-                entities: [],
-                nextLink: "",
-            }) as unknown as Xrm.Async.PromiseLike<Xrm.RetrieveMultipleResult<XrmTable.DTO.Table<string>>>;
-        }
-        if (!options) {
-            return Promise.resolve({
-                entities: [...entityDTOs],
-                nextLink: "",
-            }) as unknown as Xrm.Async.PromiseLike<Xrm.RetrieveMultipleResult<XrmTable.DTO.Table<string>>>;
-        }
-        const oDataQueryString = options?.startsWith("?") ? options.substring(1) : options;
-        const mockFilterResults = XrmMockFormODataFilter.executeRetrieveMultipleRecord(entityLogicalName, entityDTOs, oDataQueryString);
-        return Promise.resolve({
-            entities: [...mockFilterResults],
-            nextLink: "",
-        }) as unknown as Xrm.Async.PromiseLike<Xrm.RetrieveMultipleResult<XrmTable.DTO.Table<string>>>;
-    }
-
-    private UpdateRecord(entityLogicalName: string, id: string): Xrm.Async.PromiseLike<Xrm.UpdateResponse> {
-        if (this.updateServerMockDateError) {
-            return Promise.reject(new Error(this.updateServerMockDateError)) as unknown as Xrm.Async.PromiseLike<
-                Xrm.CreateResponse>;
-        }
-        return Promise.resolve(
-            { entityType: entityLogicalName, id },
-        ) as unknown as Xrm.Async.PromiseLike<Xrm.CreateResponse>;
-    }
-
-    private RetrieveSingleStubRecord(
-        entityLogicalName: string,
-        id: string,
-        options?: string
-    ): Xrm.Async.PromiseLike<Partial<XrmTable.DTO.Table<string>>> {
-        const entity = this.serverMockData[entityLogicalName];
-        if (!entity) {
-            throw new Error(`No record not found for entity ${entityLogicalName}`);
-        }
-        const record = entity.find((x) => x[`${entityLogicalName}id`] === id);
-        if (!record) {
-            throw new Error(`Record not found for entity ${entityLogicalName} with ${id}`);
-        }
-        if (options) {
-            const oDataQueryString = options?.startsWith("?") ? options.substring(1) : options;
-            const item = XrmMockFormODataFilter.executeSelectSingleRecord(record, oDataQueryString)
-            item[`${entityLogicalName}id`] = id;
-            return Promise.resolve(
-                {
-                    ...item,
-                }
-            ) as unknown as Xrm.Async.PromiseLike<Partial<XrmTable.DTO.Table<string>>>;
-        }
-        return Promise.resolve(record) as unknown as Xrm.Async.PromiseLike<Partial<XrmTable.DTO.Table<string>>>;
-    }
-
-    private GetCustomApiMockResponse(request: XrmWebApi.ExecuteRequest): Xrm.Async.PromiseLike<Response> {
-        const apiName = request.getMetadata().operationName;
-        try {
-            if (apiName) {
-                const webApiResponse = this.serverCustomApiMockData[apiName];
-                if (webApiResponse) {
-                    return Promise.resolve(new Response(JSON.stringify(webApiResponse))) as unknown as Xrm.Async.PromiseLike<Response>;
-                }
-                if (this.serverCustomApiExceptions.has(apiName)) {
-                    throw new Error(this.serverCustomApiExceptions.get(apiName));
-                }
-            }
-            return Promise.resolve(
-                new Response(JSON.stringify({ error: "no response for received request " }), {
-                    status: 400,
-                    statusText: XrmMockFormTestContextBuilder.ERROR_NO_CUSTOM_API,
-                })
-            ) as unknown as Xrm.Async.PromiseLike<Response>;
-        } catch (error: any) {
-            throw new Error(error?.message);
-        }
-    }
-
-    private UpdateControlConfig(updateAttributes: XrmFormMockAttributeControlUpdateBase<TControlName, TAttributeNames>[]): void {
-        for (const updateData of updateAttributes) {
-            const control = this.controlConfig.find((x) => {
-                if (updateData.controlSpecificName) {
-                    return x.name === updateData.controlSpecificName;
-                }
-                return x.attributeName === updateData.controlAttributeName;
-            });
-            const attribute = this.attributeConfig.find((x) => x.name === updateData.controlAttributeName) ?? null;
-            if (updateData.value !== undefined && attribute) {
-                attribute.value = updateData.value;
-            }
-            if (updateData.requiredLevel !== undefined && attribute) {
-                attribute.requiredLevel = updateData.requiredLevel;
-            }
-            if (updateData.isDirty !== undefined && attribute) {
-                attribute.isDirty = updateData.isDirty;
-            }
-            if (updateData.isVisible !== undefined && control) {
-                control.isVisible = updateData.isVisible;
-            }
-            if (updateData.isDisabled !== undefined && control) {
-                control.isDisabled = updateData.isDisabled;
-            }
-        }
-    }
-
-    private UpdateTabConfig(updateTabData: XrmFormTabUpdateData<TTabNames, TSectionNames>): void {
-        for (const [tabName, tabConfig] of Object.entries<XrmFormTabUpdateBase<TSectionNames>>(
-            updateTabData as Record<string, XrmFormTabUpdateBase<TSectionNames>>
-        )) {
-            const matchTab = this.tabConfig.find((x) => x.name === tabName);
-            if (matchTab) {
-                matchTab.displayState = tabConfig.displayState;
-                matchTab.isVisible = tabConfig.isVisible;
-                this.UpdateTabConfigSections(matchTab, tabConfig);
-            }
-        }
-    }
-
-    private UpdateTabConfigSections(
-        matchTab: XrmForm.Tester.XrmFormMockTab<TTabNames, TSectionNames, TControlName>,
-        tabConfig: XrmFormTabUpdateBase<TSectionNames>
-    ): void {
-        for (const sectionUpdate of tabConfig.sections ?? []) {
-            const matchSection = matchTab.sections.find((x) => x.name == sectionUpdate.name);
-            if (matchSection) {
-                matchSection.isVisible = sectionUpdate.isVisible;
-            }
-        }
-    }
-
-    private InitSubGridConfigMockRows(): void {
-        for (const [subGridName, subGridConfig] of this.xrmSubGridConfig) {
-            this.InitSubGridMockRows(subGridName, subGridConfig);
-        }
-    }
-
-    private InitSubGridMockRows(subGridName: TControlName, subGridConfig: XrmFormGridMockRowConfig<string>): void {
-        const subGridRows: XrmSubGridRowMocks = { selectedGridRowMocksIndexes: [...subGridConfig.selectedRowsIndexes], rows: [] };
-        for (const gridRow of subGridConfig.gridRows) {
-            const gridRowDataMock = this.CreateSubGridRowDataMock(subGridConfig.entityName, gridRow.entityId);
-            const dataMock = this.CreateSubGridRowEntityDataMock(
-                subGridConfig.subGridRowsAttributeConfig,
-                gridRow,
-                subGridConfig.entityName
-            );
-            const gridRowMock = new GridRowMock(dataMock, gridRowDataMock);
-            subGridRows.rows.push(gridRowMock);
-        }
-        this.xrmSubGridRowMocks.set(subGridName, subGridRows);
-    }
-
-    private CreateSubGridRowDataMock(entityName: string, entityId: string): GridRowDataMock {
-        const gridEntityMock = new GridEntityMock({ entityType: entityName, id: entityId });
-        return new GridRowDataMock(gridEntityMock);
-    }
-
-    private CreateSubGridRowEntityDataMock(
-        subGridConfig: XrmForm.Tester.XrmFormMockAttribute<string>[],
-        gridRow: XrmFormGridMockRowConfigRow<string>,
-        entityName: string
-    ): DataMock {
-        const attributeCollection = this.CreateSubGridAttributeDataCollection(subGridConfig, gridRow.subGridRowsAttributes);
-        const entityMock = new EntityMock({
-            entityName,
-            id: gridRow.entityId,
-            attributes: attributeCollection,
-        });
-        return new DataMock(entityMock);
-    }
-
-    private CreateSubGridAttributeDataCollection(
-        subGridConfig: XrmForm.Tester.XrmFormMockAttribute<string>[],
-        subGridRowsAttributes: XrmFormSubGridAttributeUpdateValue<string>[]
-    ): ItemCollectionMock<Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>> {
-        const mergeSubGridRowDefinition = this.MergeSubGridAttributesDefinition(subGridConfig, subGridRowsAttributes);
-        const mockAttributes: XrmMockAttributeType[] = mergeSubGridRowDefinition
-            .map((x) => this.CreateXrmMockFakeAttribute(x.name, x))
-            .filter((x): x is XrmMockAttributeType => !x);
-        return new ItemCollectionMock<Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>>(
-            <Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>[]>mockAttributes
-        );
-    }
-
-    private MergeSubGridAttributesDefinition(
-        subGridConfig: XrmForm.Tester.XrmFormMockAttribute<string>[],
-        subGridRowsAttributes: XrmFormSubGridAttributeUpdateValue<string>[]
-    ): XrmForm.Tester.XrmFormMockAttribute<string>[] {
-        return subGridConfig
-            .map((item) => ({
-                ...item,
-                options: item.options?.map((opt) => ({ ...opt })),
-                value: {
-                    ...item.value,
-                    valueLookup: item.value?.valueLookup ? item.value.valueLookup.map((valueLookup) => ({ ...valueLookup })) : undefined,
-                    valueNumberMset: item.value?.valueNumberMset ? item.value.valueNumberMset.map((valueNumber) => valueNumber) : undefined,
-                },
-            }))
-            .map((item) => {
-                const rowAttrib = subGridRowsAttributes.find((x) => x.name === item.name);
-                if (rowAttrib) {
-                    return {
-                        ...item,
-                        value: rowAttrib.value,
-                    };
-                }
-                return item;
-            });
-    }
-
-    private InitializeMockFormContextControls(): void {
-        for (const attribute of this.attributeConfig) {
-            const attributeMock = this.CreateXrmFormMockFakeAttribute(attribute.name, attribute);
-            this.InitAttributeMock(attributeMock, attribute);
-        }
-        for (const control of this.controlConfig) {
-            const controlMock = this.CreateXrmMockFakeControl(control.name, control);
-            this.InitControlMock(controlMock, control);
-        }
-        const formContext = XrmMockGenerator.getFormContext();
-        const attributeCollection = new ItemCollectionMock<Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>>(<
-            Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>[]
-            >[...this.mockAttributes.values()]);
-        const entityMock = new EntityMock({
-            ...this.formEntity,
-            attributes: attributeCollection,
-        });
-        const dataMock = new DataMock(entityMock);
-        formContext.data = dataMock;
-        formContext.data.attributes = attributeCollection;
-        formContext.data.getIsDirty = this.getIsDirty.bind(this);
-        formContext.data.entity.getId = () => this.formEntity.id ? `{${this.formEntity.id}}` : "";
-    }
-
-    private InitAttributeMock(
-        attributeMock: XrmMockAttributeType | null,
-        attribute: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>
-    ): void {
-        if (attributeMock) {
-            this.mockAttributes.set(attribute.name, attributeMock);
-            if (this.isMockAttributeChanges) {
-                const mockAddOnChange = {
-                    addOnChange: jest.fn(),
-                    removeOnChange: jest.fn(),
-                };
-                attributeMock.addOnChange = mockAddOnChange.addOnChange;
-                attributeMock.removeOnChange = mockAddOnChange.removeOnChange;
-                this.xrmFormAttributeMethodMockStubs[attribute.name] = mockAddOnChange;
-            }
-        }
-    }
-
-    private InitControlMock(
-        controlMock: XrmMockControlType | null,
-        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
-    ): void {
-        if (controlMock) {
-            if (this.isSubGridMethodsMock && this.isGridControl(controlMock)) {
-                const gridControlMock = {
-                    refresh: jest.fn(),
-                    addOnLoad: jest.fn(),
-                    getGrid: jest.fn((): Xrm.Controls.Grid => this.CreateMockGrid(control)),
-                    setFilterXml: jest.fn((_): void => { }),
-                };
-                this.xrmSubGridControlMockStubs[control.name] = gridControlMock;
-                controlMock.addOnLoad = gridControlMock.addOnLoad;
-                controlMock.refresh = gridControlMock.refresh;
-                controlMock.getGrid = gridControlMock.getGrid;
-                (<any>controlMock).setFilterXml = gridControlMock.setFilterXml;
-            }
-            if (this.isControlLookupMethodMock && this.isLookupControl(controlMock)) {
-                const lookupControlMock = {
-                    removePreSearch: jest.fn(),
-                    addPreSearch: jest.fn(),
-                    setEntityTypes: jest.fn((entityType: string[]) => { controlMock.entityTypes = entityType; }),
-                    addCustomFilter: jest.fn(),
-                };
-                controlMock.removePreSearch = lookupControlMock.removePreSearch;
-                controlMock.addPreSearch = lookupControlMock.addPreSearch;
-                controlMock.setEntityTypes = lookupControlMock.setEntityTypes;
-                controlMock.addCustomFilter = lookupControlMock.addCustomFilter;
-                this.xrmLookupControlMockStubs[control.name] = lookupControlMock;
-            }
-            if (this.isControlMethodMock && !this.isGridControl(controlMock)) {
-                const standardControl = {
-                    addNotification: jest.fn(),
-                    clearNotification: jest.fn(),
-                    setFocus: jest.fn(),
-                    clearOptions: jest.fn(),
-                };
-                controlMock.addNotification = standardControl.addNotification;
-                controlMock.clearNotification = standardControl.clearNotification;
-                controlMock.setFocus = standardControl.setFocus;
-                if (this.isOptionSetControl(controlMock)) {
-                    standardControl.clearOptions = jest.fn().mockImplementation(function (this: OptionSetControlMock) {
-                        const optLength = this.options.length;
-                        if (optLength) {
-                            this.options.splice(0, optLength);
-                        }
-                        const attOptLength = this.attribute.options.length
-                        if (attOptLength) {
-                            this.attribute.options.splice(0, attOptLength);
-                        }
-                    });
-                    controlMock.clearOptions = standardControl.clearOptions;
-                    this.xrmOptionSetControlMockStubs[control.name] = standardControl;
-                } else {
-                    this.xrmStandardControlMockStubs[control.name] = standardControl;
-                }
-            }
-            this.mockControls.set(control.name, controlMock);
-        }
-    }
-
-    private InitTabs(): this {
-        for (const tabSection of this.tabConfig) {
-            this.InitTab(tabSection);
-        }
-        return this;
-    }
-
-    private InitTab(tab: XrmForm.Tester.XrmFormMockTab<TTabNames, TSectionNames, TControlName>): this {
-        const mockTab = XrmMockGenerator.Tab.createTab(tab.name, tab.label, tab.isVisible, tab.displayState ?? "collapsed", tab.parent);
-        if (this.isMockTabEvents) {
-            const tabEvent = {
-                addTabStateChange: jest.fn(),
-                removeTabStateChange: jest.fn(),
-                setFocus: jest.fn(),
-            };
-            mockTab.addTabStateChange = tabEvent.addTabStateChange;
-            mockTab.removeTabStateChange = tabEvent.removeTabStateChange;
-            mockTab.setFocus = tabEvent.setFocus;
-            this.xrmTabEventsStub[tab.name] = tabEvent;
-        }
-        for (const tabSection of tab.sections) {
-            this.InitTabSection(mockTab, tabSection);
-        }
-        return this;
-    }
-
-    private InitPreSaveMock(): void {
-        this.xrmPreSaveEvent = jest.fn();
-        XrmMockGenerator.getFormContext().data.entity.addOnSave = this.xrmPreSaveEvent;
-    }
-
-    private InitTabSection(tab: TabMock, section: XrmForm.Tester.XrmFormMockTabSection<TSectionNames, TControlName>): this {
-        const controls = this.FilterControlList(section.controlNames);
-        const controlCollection: ItemCollectionMock<Xrm.Controls.Control> = new ItemCollectionMock<Xrm.Controls.Control>(
-            <Xrm.Controls.Control[]>controls
-        );
-        XrmMockGenerator.Section.createSection(
-            section.name,
-            section.label ?? section.name,
-            section.isVisible ?? false,
-            tab,
-            controlCollection
-        );
-        return this;
-    }
-
-    private FilterControlList(controlNames: TControlName[]): XrmMockControlType[] {
-        return (
-            controlNames
-                .map((name) => this.mockControls.get(name))
-                .filter((x): x is XrmMockControlType => {
-                    return x !== null && x !== undefined;
-                }) ?? []
-        );
-    }
-
-    // Creates mock attributes in the context of the static XrmMockGenerator
-    private CreateXrmFormMockFakeAttribute(
-        name: string,
-        mockAttribute: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>
-    ): XrmMockAttributeType | null {
-        switch (mockAttribute.type) {
-            case "string":
-                return XrmMockGenerator.Attribute.createString({
-                    name,
-                    value: mockAttribute.value?.valueString,
-                    isDirty: mockAttribute?.isDirty,
-                    requiredLevel: mockAttribute?.requiredLevel,
-                });
-            case "boolean":
-                return this.CreateFormContextBooleanWithNullReturn(name, mockAttribute);
-            case "date":
-                return XrmMockGenerator.Attribute.createDate({
-                    name,
-                    value: mockAttribute.value?.valueDate,
-                    isDirty: mockAttribute?.isDirty,
-                    requiredLevel: mockAttribute?.requiredLevel,
-                });
-            case "number":
-                return XrmMockGenerator.Attribute.createNumber({
-                    name,
-                    value: mockAttribute.value?.valueNumber,
-                    isDirty: mockAttribute?.isDirty,
-                    requiredLevel: mockAttribute?.requiredLevel,
-                });
-            case "lookup":
-                return XrmMockGenerator.Attribute.createLookup({
-                    name,
-                    value: mockAttribute.value?.valueLookup ?? null,
-                    isDirty: mockAttribute?.isDirty,
-                    requiredLevel: mockAttribute?.requiredLevel,
-                });
-            case "optionSet":
-                return XrmMockGenerator.Attribute.createOptionSet({
-                    name,
-                    value: mockAttribute.value?.valueNumber,
-                    options: mockAttribute.options ?? [],
-                    isDirty: mockAttribute?.isDirty,
-                    requiredLevel: mockAttribute?.requiredLevel,
-                });
-            case "multiSet":
-                // xrm-mock does not handle multipset controls properly
-                return this.CreateFormContextMultiSelectAttributeMock(name, mockAttribute);
-            // case "Xrm.Controls.GridControl":
-            // case "Xrm.Controls.KbSearchControl":
-            // case "Xrm.Control.QuickFormControl":
-            // TO BE DONE MOCK GRID CONTROL
-            // return null;
-            default:
-                return null;
-        }
-    }
-
-    // Creates mock attributes not as part of the XrmMockGenerator , e.g. for the subGrid attributes
-    private CreateXrmMockFakeAttribute(
-        name: string,
-        mockAttribute: XrmForm.Tester.XrmFormMockAttribute<string>
-    ): XrmMockAttributeType | null {
-        switch (mockAttribute.type) {
-            case "string":
-                return new StringAttributeMock({
-                    name,
-                    value: mockAttribute.value?.valueString,
-                    isDirty: mockAttribute?.isDirty,
-                    requiredLevel: mockAttribute?.requiredLevel,
-                });
-            case "boolean":
-                return new BooleanAttributeMock({
-                    name,
-                    value: mockAttribute.value?.valueBoolean,
-                    isDirty: mockAttribute?.isDirty,
-                    requiredLevel: mockAttribute?.requiredLevel,
-                });
-            case "date":
-                return new DateAttributeMock({
-                    name,
-                    value: mockAttribute.value?.valueDate,
-                    isDirty: mockAttribute?.isDirty,
-                    requiredLevel: mockAttribute?.requiredLevel,
-                });
-            case "number":
-                return new NumberAttributeMock({
-                    name,
-                    value: mockAttribute.value?.valueNumber,
-                    isDirty: mockAttribute?.isDirty,
-                    requiredLevel: mockAttribute?.requiredLevel,
-                });
-            case "lookup":
-                return new LookupAttributeMock({
-                    name,
-                    value: mockAttribute.value?.valueLookup ?? null,
-                    isDirty: mockAttribute?.isDirty,
-                    requiredLevel: mockAttribute?.requiredLevel,
-                });
-            case "optionSet":
-                return new OptionSetAttributeMock({
-                    name,
-                    value: mockAttribute.value?.valueNumber,
-                    options: mockAttribute.options ?? [],
-                    isDirty: mockAttribute?.isDirty,
-                    requiredLevel: mockAttribute?.requiredLevel,
-                });
-            case "multiSet":
-                // xrm-mock does not handle multi set controls properly
-                return this.CreateMultiSelectAttributeMock(name, mockAttribute);
-            // case "Xrm.Controls.GridControl":
-            // case "Xrm.Controls.KbSearchControl":
-            // case "Xrm.Control.QuickFormControl":
-            // TO BE DONE MOCK GRID CONTROL
-            // return null;
-            default:
-                return null;
-        }
-    }
-
-    private CreateFormContextMultiSelectAttributeMock(
-        name: string,
-        mockAttribute: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>
-    ): OptionSetAttributeMock {
-        const multiOptionSetAttr = this.CreateMultiSelectAttributeMock(name, mockAttribute);
-        return multiOptionSetAttr;
-    }
-
-    private CreateMultiSelectAttributeMock(
-        name: string,
-        mockAttribute: XrmForm.Tester.XrmFormMockAttribute<string>
-    ): OptionSetAttributeMock {
-        const multiOptionSetAttr = new OptionSetAttributeMock({
-            name,
-            value: (mockAttribute.value?.valueNumberMset ?? []) as any,
-            options: mockAttribute.options ?? [],
-            isDirty: mockAttribute?.isDirty,
-            requiredLevel: mockAttribute?.requiredLevel,
-        }) as unknown as Xrm.Attributes.MultiSelectOptionSetAttribute;
-        multiOptionSetAttr.getSelectedOption = (): Xrm.OptionSetValue[] => {
-            const currentValues: number[] = multiOptionSetAttr.getValue() || [];
-            return (mockAttribute.options ?? []).filter((opt) => currentValues.includes(opt.value));
-        };
-        return multiOptionSetAttr as unknown as OptionSetAttributeMock;
-    }
-
-    private CreateFormContextBooleanWithNullReturn(
-        name: string,
-        mockAttribute: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>
-    ): BooleanAttributeMock {
-        const initialValue = mockAttribute.value?.valueBoolean === null ? undefined : mockAttribute.value?.valueBoolean;
-        const attributeBoolean = XrmMockGenerator.Attribute.createBoolean({
-            name,
-            initialValue: initialValue,
-            value: initialValue,
-            isDirty: mockAttribute?.isDirty,
-            requiredLevel: mockAttribute?.requiredLevel,
-        });
-        // Known gap of xrm-mock which cannot properly handle the return of empty/null values force the initial assignment to mock the real dynamics behavior
-        attributeBoolean.value = mockAttribute.value?.valueBoolean as any;
-        return attributeBoolean;
-    }
-
-    private CreateXrmMockFakeControl(
-        name: string,
-        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
-    ): XrmMockControlType | null {
-        const mockAttribute = control.attributeName ? this.mockAttributes.get(control.attributeName) : null;
-        switch (control.type) {
-            case "string":
-                return this.CreateStringMockControl(mockAttribute, control);
-            case "boolean":
-                return this.CreateBooleanMockControl(mockAttribute, control);
-            case "date":
-                return this.CreateDateMockControl(mockAttribute, control);
-            case "number":
-                return this.CreateNumberMockControl(mockAttribute, control);
-            case "lookup":
-                return this.CreateLookupControl(mockAttribute, control);
-            case "optionSet":
-                return this.CreateOptionSetControl(mockAttribute, control);
-            case "multiSet":
-                return this.CreateMultiOptionSetControl(mockAttribute, control);
-            case "gridControl":
-                return XrmMockGenerator.Control.createGrid(name);
-            case "quickView":
-                // create function for quick views
-                return null;
-
-            // case "Xrm.Controls.KbSearchControl":
-            // case "Xrm.Control.QuickFormControl":
-            // case "Xrm.Controls.IframeControl":
-            // case "Xrm.Controls.StandardControl":
-            //     NO MAPPING ON THIS CONTROLS
-            //     return null;
-            default:
-                return null;
-        }
-    }
-
-    private CreateStringMockControl(
-        mockAttribute: XrmMockAttributeType | null | undefined,
-        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
-    ): StringControlMock | null {
-        if (mockAttribute && control.name) {
-            return XrmMockGenerator.Control.createString({
-                name: control.name,
-                attribute: <StringAttributeMock>mockAttribute,
-                visible: control.isVisible,
-                disabled: control.isDisabled,
-            });
-        }
-        return null;
-    }
-
-    private CreateBooleanMockControl(
-        mockAttribute: XrmMockAttributeType | null | undefined,
-        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
-    ): BooleanControlMock | null {
-        if (mockAttribute && control.name) {
-            return XrmMockGenerator.Control.createBoolean({
-                name: control.name,
-                attribute: <BooleanAttributeMock>mockAttribute,
-                visible: control.isVisible,
-                disabled: control.isDisabled,
-            });
-        }
-        return null;
-    }
-
-    private CreateDateMockControl(
-        mockAttribute: XrmMockAttributeType | null | undefined,
-        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
-    ): DateControlMock | null {
-        if (mockAttribute && control.name) {
-            return XrmMockGenerator.Control.createDate({
-                name: control.name,
-                attribute: <DateAttributeMock>mockAttribute,
-                visible: control.isVisible,
-                disabled: control.isDisabled,
-            });
-        }
-        return null;
-    }
-
-    private CreateNumberMockControl(
-        mockAttribute: XrmMockAttributeType | null | undefined,
-        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
-    ): NumberControlMock | null {
-        if (mockAttribute && control.name) {
-            return XrmMockGenerator.Control.createNumber({
-                name: control.name,
-                attribute: <NumberAttributeMock>mockAttribute,
-                visible: control.isVisible,
-                disabled: control.isDisabled,
-            });
-        }
-        return null;
-    }
-
-    private CreateLookupControl(
-        mockAttribute: XrmMockAttributeType | null | undefined,
-        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
-    ): LookupControlMock | null {
-        if (mockAttribute && control.name) {
-            return XrmMockGenerator.Control.createLookup({
-                name: control.name,
-                attribute: <LookupAttributeMock>mockAttribute,
-                visible: control.isVisible,
-                disabled: control.isDisabled,
-            });
-        }
-        return null;
-    }
-
-    private CreateOptionSetControl(
-        mockAttribute: XrmMockAttributeType | null | undefined,
-        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
-    ): OptionSetControlMock | null {
-        if (mockAttribute && control.name) {
-            const mockOptions = (<OptionSetAttributeMock>mockAttribute).options ?? [];
-            return XrmMockGenerator.Control.createOptionSet({
-                name: control.name,
-                attribute: <OptionSetAttributeMock>mockAttribute,
-                visible: control.isVisible,
-                options: mockOptions.map(opt => ({ ...opt })),
-                disabled: control.isDisabled,
-            });
-        }
-        return null;
-    }
-
-    private CreateMultiOptionSetControl(
-        mockAttribute: XrmMockAttributeType | null | undefined,
-        control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>
-    ): OptionSetControlMock | null {
-        if (mockAttribute && control.name) {
-            const mockOptions = (<OptionSetAttributeMock>mockAttribute).options ?? [];
-            return XrmMockGenerator.Control.createOptionSet({
-                name: control.name,
-                attribute: mockAttribute as any,
-                visible: control.isVisible,
-                options: mockOptions.map(opt => ({ ...opt })),
-                disabled: control.isDisabled,
-            });
-        }
-        return null;
-    }
-
-    private CreateMockGrid(control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>): GridMock {
-        const gridRows = this.xrmSubGridRowMocks.get(control.name);
-        if (!gridRows) {
-            return new GridMock(new ItemCollectionMock([]), new ItemCollectionMock([]));
-        }
-        const selectedRows = gridRows.rows.filter((_, index) => {
-            if (gridRows.selectedGridRowMocksIndexes.length > 0) {
-                return gridRows.selectedGridRowMocksIndexes.includes(index);
-            }
-            return false;
-        });
-        return new GridMock(new ItemCollectionMock(gridRows.rows), new ItemCollectionMock(selectedRows));
-    }
-
-    private MapFormContext(): ContextMock {
-        const context = Context.createContext();
-        context.clientUrl = this.clientUrl ?? "";
-        context.userSettings.languageId = this.languageId;
-        context.userSettings.roles = new ItemCollectionMock(this.userRoles);
-        return context;
-    }
-
-    private getIsDirty() {
-        return Array.from(this.mockAttributes).some(([name, attr]) => attr.isDirty);
-    }
-
-    private isGridControl(control: XrmMockControlType | null): control is GridControlMock {
-        if (!control) {
-            return false;
-        }
-        const controlType = control.getControlType();
-        return controlType === "subgrid";
-    }
-
-    private isLookupControl(control: XrmMockControlType | null): control is LookupControlMock {
-        if (!control) {
-            return false;
-        }
-        const controlType = control.getControlType();
-        return controlType === "lookup";
-    }
-
-    private isOptionSetControl(control: XrmMockControlType | null): control is OptionSetControlMock {
-        if (!control) {
-            return false;
-        }
-        const controlType = control.getControlType();
-        return controlType === "optionset";
-    }
+	TTabNames extends string,
+	TSectionNames extends string,
+	TControlName extends string,
+	TAttributeNames extends string,
+> implements
+		IXrmMockFormTestContextBuilder<
+			TTabNames,
+			TSectionNames,
+			TControlName,
+			TAttributeNames
+		>
+{
+	public static readonly ERROR_NO_CUSTOM_API = "Bad Request";
+	public xrmWebApiMockStubs: XrmWebApiMockStubs = {};
+	public xrmWebApiOnlineMockStubs: XrmWebApiOnlineMockStubs = {};
+	public xrmNavigationMockStubs: XrmNavigationMockStubs = {};
+	public xrmUiFormMocksStubs: XrmFormContextUiMockStubs = {};
+	public xrmUtilityApiMockStubs: XrmUtilityApiMockStubs = {};
+	public xrmFormAttributeMethodMockStubs: XrmFormAttributeMethodMockStubs<TAttributeNames> =
+		{};
+	public xrmSubGridControlMockStubs: XrmSubGridControlMockStubs<TControlName> =
+		{};
+	public xrmFormSelectorMockStub: XrmFormSelectorMockStubs = {};
+	public xrmStandardControlMockStubs: XrmStandardControlMockStubs<TControlName> =
+		{};
+	public xrmOptionSetControlMockStubs: XrmOptionSetControlMockStubs<TControlName> =
+		{};
+	public xrmLookupControlMockStubs: XrmLookupControlMockStubs<TControlName> =
+		{};
+	public xrmTabEventsStub: XrmFormContextTabEventsStub<TTabNames> = {};
+	public xrmFormDataMockStubs: XrmFormContextDataMockStubs = {};
+	public xrmConsoleMockStubs: XrmConsoleMockStubs = {};
+	public xrmFetchMockStubs: jest.Mock | null = null;
+	public xrmPreSaveEvent: jest.Mock | null = null;
+	public formEntity: IEntityComponents = {};
+
+	private readonly xrmSubGridConfig: Map<
+		TControlName,
+		XrmFormGridMockRowConfig<string>
+	> = new Map<TControlName, XrmFormGridMockRowConfig<string>>();
+	private readonly xrmSubGridRowMocks: Map<TControlName, XrmSubGridRowMocks> =
+		new Map<TControlName, XrmSubGridRowMocks>();
+	private formType: XrmEnum.FormType = XrmEnum.FormType.Create; //default value
+	private confirmDialogConfirmedSeq: XrmMockConfirmDialogResponses[] = [];
+	private isMockAttributeChanges: boolean = false;
+	private isSubGridMethodsMock: boolean = false;
+	private isControlMethodMock: boolean = false;
+	private isMockTabEvents: boolean = false;
+	private isMockPreSaveEvent: boolean = false;
+	private isMockFormDateEvent: boolean = false;
+	private isMockFormUiEvent: boolean = false;
+	private isFormDataValid: boolean = false;
+	private isFormDataDirty: boolean = false;
+	private isConsoleMocked: boolean = false;
+	private isControlLookupMethodMock: boolean = false;
+	private saveErrorMessage: string | null = null;
+	private refreshErrorMessage: string | null = null;
+	private userRoles: Xrm.LookupValue[] = [];
+	private languageId: number = 1033;
+	private clientUrl: string | null = null;
+	private formSelectorItems: XrmFormMockFormItem[] = [];
+	private retrieveServerMockDateError: string | null = null;
+	private updateServerMockDateError: string | null = null;
+	private readonly mockAttributes: Map<TAttributeNames, XrmMockAttributeType>;
+	private readonly mockControls: Map<TControlName, XrmMockControlType>;
+	private readonly controlConfig: XrmForm.Tester.XrmFormMockControl<
+		TControlName,
+		TAttributeNames
+	>[];
+	private readonly attributeConfig: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>[];
+	private readonly tabConfig: XrmForm.Tester.XrmFormMockTab<
+		TTabNames,
+		TSectionNames,
+		TControlName
+	>[];
+	private readonly serverMockData: XrmFormMockServerData = {};
+	private readonly serverCustomApiMockData: XrmCustomApiMockData = {};
+	private readonly serverCustomApiExceptions: Map<string, string>;
+
+	/**
+	 * @summary Default constructor function
+	 * @param initialControlsConfig Configuration for control names/ types / status and related attributes
+	 * @param initialAttributesConfig Configuration for attribute names/ types / values, required level
+	 * @param initialTabsConfig Configuration for tab/section/controls
+	 */
+	constructor(
+		initialControlsConfig: XrmForm.Tester.XrmFormMockControl<
+			TControlName,
+			TAttributeNames
+		>[],
+		initialAttributesConfig: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>[],
+		initialTabsConfig: XrmForm.Tester.XrmFormMockTab<
+			TTabNames,
+			TSectionNames,
+			TControlName
+		>[],
+	) {
+		// Gets inputs from the generated files with the form description
+		this.mockAttributes = new Map<TAttributeNames, XrmMockAttributeType>();
+		this.mockControls = new Map<TControlName, XrmMockControlType>();
+		this.serverCustomApiExceptions = new Map<string, string>();
+		this.controlConfig = initialControlsConfig.map((item) => ({ ...item }));
+		this.attributeConfig = initialAttributesConfig.map((item) => ({
+			...item,
+			options: item.options?.map((opt) => ({ ...opt })),
+			value: {
+				...item.value,
+				valueLookup: item.value?.valueLookup
+					? item.value.valueLookup.map((valueLookup) => ({ ...valueLookup }))
+					: undefined,
+				valueNumberMset: item.value?.valueNumberMset
+					? item.value.valueNumberMset.map((valueNumber) => valueNumber)
+					: undefined,
+			},
+		}));
+		this.tabConfig = initialTabsConfig.map((item) => ({
+			...item,
+			sections: item.sections.map((section) => ({
+				...section,
+				controlNames: section.controlNames.map((x) => x),
+			})),
+		}));
+		this.formEntity = {
+			id: crypto.randomUUID(),
+			entityName: "defaultEntity",
+		};
+	}
+	/**
+	 * @summary Simple function to get the correctly mapped load event with arguments to pass to form load
+	 * @returns the mock load event to be passed to the onload form event
+	 */
+	public getLoadExecutionContext(): EventContextWithEventArgsMock<Xrm.Events.LoadEventArguments> {
+		const eventContext =
+			XrmMockGenerator.getEventContext() ?? new EventContextMock({});
+		const eventArgs: Xrm.Events.LoadEventArguments = {
+			getDataLoadState: () => XrmEnum.FormDataLoadState.InitialLoad,
+		};
+
+		return new EventContextWithEventArgsMock<Xrm.Events.LoadEventArguments>({
+			context: eventContext.context,
+			depth: eventContext.depth,
+			eventArgs: eventArgs,
+			eventSource: eventContext.eventSource,
+			formContext: eventContext.formContext,
+			sharedVariables: eventContext.sharedVariables,
+		});
+	}
+
+	/**
+	 * Get mock form context with specific provided type
+	 * @returns
+	 */
+	public getMockFormContext<T extends Xrm.FormContext>(): T {
+		return <T>this.getLoadExecutionContext().getFormContext();
+	}
+
+	/**
+	 * Generate an form even execution context with a input control source event
+	 * @param source
+	 * @returns
+	 */
+	public getExecutionContextWithSource(
+		source:
+			| Xrm.Attributes.Attribute
+			| Xrm.Controls.Control
+			| Xrm.Controls.Tab
+			| Xrm.Entity,
+	): EventContextWithEventArgsMock<Xrm.Events.EventContext> {
+		const eventContext =
+			XrmMockGenerator.getEventContext() ?? new EventContextMock({});
+		return new EventContextWithEventArgsMock<Xrm.Events.EventContext>({
+			context: eventContext.context,
+			depth: eventContext.depth,
+			eventSource: source as unknown as
+				| Xrm.Attributes.Attribute
+				| Xrm.Controls.Control
+				| Xrm.Entity,
+			formContext: eventContext.formContext,
+			sharedVariables: eventContext.sharedVariables,
+		});
+	}
+
+	/**
+	 * Generate a form asyn event context
+	 * @param source
+	 * @returns
+	 */
+	public getSaveAsyncEventContext(): EventContextWithEventArgsMock<Xrm.Events.SaveEventArgumentsAsync> {
+		const eventContext =
+			XrmMockGenerator.getEventContext() ?? new EventContextMock({});
+		const eventArgs: Xrm.Events.SaveEventArgumentsAsync = {
+			disableAsyncTimeout: jest.fn(),
+			getSaveMode: jest.fn(),
+			isDefaultPrevented: jest.fn(),
+			preventDefault: jest.fn(),
+			preventDefaultOnError: jest.fn(),
+		};
+		return new EventContextWithEventArgsMock<Xrm.Events.SaveEventArgumentsAsync>(
+			{
+				context: eventContext.context,
+				depth: eventContext.depth,
+				formContext: eventContext.formContext,
+				sharedVariables: eventContext.sharedVariables,
+				eventArgs: eventArgs,
+			},
+		);
+	}
+
+	/**
+	 * Given the form context config and data it generates the xrm-mock form, needs to be called before the test starts
+	 * @returns The object itself
+	 */
+	public buildMockFormContext(): this {
+		XrmMockGenerator.initialise({
+			context: this.MapFormContext(),
+			entity: this.formEntity,
+			process: undefined,
+		});
+
+		// If sub grid mock config, then init subGrid row mocks before controls as controls mocks use it
+		if (this.isSubGridMethodsMock && this.xrmSubGridConfig.size > 0) {
+			this.InitSubGridConfigMockRows();
+		}
+		this.InitializeMockFormContextControls();
+		this.InitTabs();
+		this.InitXrmNavigationApiMocks();
+		this.InitXrmUtilityMocks();
+		this.InitFormUiSelector();
+
+		if (this.isMockFormDateEvent) {
+			this.InitMockFormDataEvent();
+		}
+		if (this.isMockFormUiEvent) {
+			this.InitFormUiMocks();
+		}
+		if (this.serverMockData) {
+			this.InitXrmWebApiServerMocks();
+		}
+		if (
+			this.serverCustomApiMockData ||
+			this.serverCustomApiExceptions.size > 0
+		) {
+			this.InitXrmWebApiOnlineMocks();
+		}
+		if (this.isMockPreSaveEvent) {
+			this.InitPreSaveMock();
+		}
+		if (this.isConsoleMocked) {
+			this.InitConsoleMock();
+		}
+		return this;
+	}
+
+	/**
+	 * Modifies the default form context config with the given update data
+	 * @param updateData Simply array with the control/attributes to be changed
+	 * @returns the object itself
+	 */
+	public withFormAttributeControlData(
+		updateData: XrmFormMockAttributeControlUpdateBase<
+			TControlName,
+			TAttributeNames
+		>[],
+	): this {
+		this.UpdateControlConfig(updateData);
+		return this;
+	}
+
+	/**
+	 * Set the entity id with update form data
+	 * @param updateData
+	 * @returns
+	 */
+	public withFormTabData(
+		updateData: XrmFormTabUpdateData<TTabNames, TSectionNames>,
+	): this {
+		this.UpdateTabConfig(updateData);
+		return this;
+	}
+
+	/***
+	 * Set the entity id of the form so it is returned when calling entity.GetId()
+	 * @param recordId unique id of the form entity
+	 */
+	public withEntity(entityName: string, entityId: string): this {
+		this.formEntity = {
+			entityName,
+			id: entityId,
+		};
+		return this;
+	}
+
+	/**
+	 * To set the form type on creation
+	 * @param formType Form type of the form context
+	 * @returns
+	 */
+	public withFormType(formType: XrmEnum.FormType): this {
+		this.formType = formType;
+		return this;
+	}
+
+	/**
+	 * Setup a fake server data to be returned by the sino stubs
+	 * @param data Simple array of entity lists to be a fake for stubs to return
+	 */
+	public withServerData(data: XrmFormMockServerData): this {
+		Object.assign(this.serverMockData, data);
+		return this;
+	}
+
+	/**
+	 * Configure sub grid mocks to only contain selected rows identified by their entity ids
+	 * @param name control name of the sub grid
+	 * @param entityName logical name of the entities shown in the sub grid
+	 * @param selectedIds entity ids of the rows that should be selected
+	 * @returns
+	 */
+	public withSelectedSubGridRows(
+		name: TControlName,
+		entityName: string,
+		selectedIds: string[],
+	): this {
+		this.isSubGridMethodsMock = true;
+		return this.withSubGridMockRows<string>({
+			entityName,
+			subGridRowsAttributeConfig: [],
+			gridRows: selectedIds.map((id) => ({
+				entityId: id,
+				subGridRowsAttributes: [],
+			})),
+			selectedRowsIndexes: selectedIds.map((_, i) => i),
+		});
+	}
+
+	/**
+	 * With error message when calling server retrieve
+	 * @param erroMsg
+	 * @returns
+	 */
+	public withRetrieveServerDataError(erroMsg: string): this {
+		this.retrieveServerMockDateError = erroMsg;
+		return this;
+	}
+
+	/**
+	 * With error message when calling server update
+	 * @param erroMsg
+	 * @returns
+	 */
+	public withUpdateServerDateErrorMessage(erroMsg: string): this {
+		this.updateServerMockDateError = erroMsg;
+		return this;
+	}
+
+	/**
+	 * Configure a list of custom api mock data that the test context builder will contain
+	 * @param data Object containing a map of custom api names and the mock responses
+	 * @returns
+	 */
+	public withCustomApis(data: XrmCustomApiMockData): this {
+		Object.assign(this.serverCustomApiMockData, data);
+		return this;
+	}
+
+	/**
+	 * Configure a single custom api with name + response
+	 * @param name
+	 * @param response
+	 * @returns
+	 */
+	public withCustomApi<T extends XrmWebApi.ExecuteResponse>(
+		name: string,
+		response: T,
+	): this {
+		this.serverCustomApiMockData[name] = response;
+		return this;
+	}
+
+	/**
+	 * Configure single custom api to return exception for unhandled exception catch handling
+	 * @param name
+	 * @param errorMsg
+	 */
+	public withCustomApiException(name: string, errorMsg: string): this {
+		this.serverCustomApiExceptions.set(name, errorMsg);
+		return this;
+	}
+
+	/**
+	 * Configure the sequence of confirm cancel dialog response for the form context calls
+	 * @param confirmDialogConfirmed
+	 */
+	public withUserConfirmDialogSeq(confirmDialogConfirmed: boolean[]): this {
+		this.confirmDialogConfirmedSeq = confirmDialogConfirmed.map((x) => ({
+			confirmed: x,
+			executed: false,
+		}));
+		return this;
+	}
+
+	/**
+	 * Configure if we need a jest attribute mock changes
+	 * @param isMockAttributeChanges
+	 * @returns
+	 */
+	public withAttributeMockChange(isMockAttributeChanges: boolean): this {
+		this.isMockAttributeChanges = isMockAttributeChanges;
+		return this;
+	}
+
+	/**
+	 * Configure if you want to jest mock sub grid mock loads
+	 * @param isSubGridLoad
+	 * @returns
+	 */
+	public withSubGridMethodsMock(isSubGridLoad: boolean): this {
+		this.isSubGridMethodsMock = isSubGridLoad;
+		return this;
+	}
+
+	/**
+	 * Control if you want to jest mock control mocks
+	 * @param isControlMethodMock
+	 * @returns
+	 */
+	public WithControlMethodMock(isControlMethodMock: boolean): this {
+		this.isControlMethodMock = isControlMethodMock;
+		return this;
+	}
+
+	/**
+	 * Configure if you want to jest mock tab events
+	 * @param isMockTabEvents
+	 * @returns
+	 */
+	public withRegisterTabEventsMocks(isMockTabEvents: boolean): this {
+		this.isMockTabEvents = isMockTabEvents;
+		return this;
+	}
+
+	/**
+	 * Configure is you want to jest mock save events
+	 * @param isPreSaveEventMock
+	 * @returns
+	 */
+	public withPreSaveEventMock(isPreSaveEventMock: boolean): this {
+		this.isMockPreSaveEvent = isPreSaveEventMock;
+		return this;
+	}
+
+	/**
+	 * Set form context language id to be returned by the getGlobalContext
+	 * @param languageId
+	 * @returns
+	 */
+	public withLanguageId(languageId: number): this {
+		this.languageId = languageId;
+		return this;
+	}
+
+	/**
+	 * Set form context client url
+	 * @param clientUrl
+	 * @returns
+	 */
+	public withClientUrl(clientUrl: string): this {
+		this.clientUrl = clientUrl;
+		return this;
+	}
+
+	/**
+	 * Set form context user roles to be returned by the getGlobalContext
+	 * @param roles
+	 * @returns
+	 */
+	public withUserRoles(roles: Xrm.LookupValue[]): this {
+		this.userRoles = roles;
+		return this;
+	}
+
+	/**
+	 * Configure if you want to jest mock form data events
+	 * @param isMockFormDateEventMock
+	 * @returns
+	 */
+	public withFormDataEventMock(isMockFormDateEventMock: boolean): this {
+		this.isMockFormDateEvent = isMockFormDateEventMock;
+		return this;
+	}
+
+	/**
+	 * Configure if you want to jest mock form ui events
+	 * @param isMockFormUiEvent
+	 * @returns
+	 */
+	public withFormUiEventMock(isMockFormUiEvent: boolean): this {
+		this.isMockFormUiEvent = isMockFormUiEvent;
+		return this;
+	}
+
+	/**
+	 * Configure if form data valid mock returns specific value
+	 * @param isValid
+	 * @returns
+	 */
+	public withFormDataValid(isValid: boolean): this {
+		this.isFormDataValid = isValid;
+		return this;
+	}
+
+	/**
+	 * Configure if form data valid mock returns specific value
+	 * @param isDirty
+	 * @returns
+	 */
+	public withFormDataDirty(isDirty: boolean): this {
+		this.isFormDataDirty = isDirty;
+		return this;
+	}
+
+	/**
+	 * Configure so form data save returns an error message
+	 * @param isDirty
+	 * @returns
+	 */
+	public withSaveErrorMessage(errorMsg: string | null): this {
+		this.saveErrorMessage = errorMsg;
+		return this;
+	}
+
+	/**
+	 * Configure form data refresh returns an error message
+	 * @param errorMsg
+	 * @returns
+	 */
+	public withRefreshErrorMessage(errorMsg: string | null): this {
+		this.refreshErrorMessage = errorMsg;
+		return this;
+	}
+
+	/**
+	 * Configure a console log mock to assertions on to of console statements
+	 * @param isConsoleMocked
+	 * @returns
+	 */
+	public withConsoleMocked(isConsoleMocked: boolean): this {
+		this.isConsoleMocked = isConsoleMocked;
+		return this;
+	}
+
+	/**
+	 * Add a mock for a simple fetch with a certain response
+	 * @param statusCode
+	 * @param response
+	 */
+	public withFetchResponse(statusCode: number, response: string): this {
+		this.xrmFetchMockStubs = jest.fn(
+			(_url: URL | RequestInfo): Promise<Response> => {
+				const isOK = statusCode >= 200 && statusCode <= 299;
+				return Promise.resolve(
+					new Response(response, {
+						status: statusCode,
+						statusText: isOK ? "OK" : "Internal Error",
+					}),
+				);
+			},
+		);
+		globalThis.fetch = this.xrmFetchMockStubs;
+		return this;
+	}
+
+	/**
+	 * Add a mock for a simple fetch with a certain response
+	 * @param statusCode
+	 * @param response
+	 */
+	public withFetchException(errorMsg: string): this {
+		this.xrmFetchMockStubs = jest.fn(
+			(_url: URL | RequestInfo): Promise<Response> => {
+				throw new Error(errorMsg);
+			},
+		);
+		globalThis.fetch = this.xrmFetchMockStubs;
+		return this;
+	}
+
+	/**
+	 * Configure sub grid mocks to be able to interact with the sub grid rows attributes
+	 * @param name
+	 * @param updateGridRows
+	 * @returns
+	 */
+	public withSubGridMockRows<TGridAttributeNames extends string>(
+		name: TControlName,
+		updateGridRows: XrmFormGridMockRowConfig<TGridAttributeNames>,
+	): this {
+		if (
+			!updateGridRows.selectedRowsIndexes.every(
+				(index) => index >= 0 && index < updateGridRows.gridRows.length,
+			)
+		) {
+			throw new Error(
+				"Wrong input selectedRowsIndexes value over length of rows",
+			);
+		}
+		this.xrmSubGridConfig.set(name, {
+			...updateGridRows,
+			subGridRowsAttributeConfig: updateGridRows.subGridRowsAttributeConfig.map(
+				(item) => ({
+					...item,
+					options: item.options?.map((opt) => ({ ...opt })),
+					value: {
+						...item.value,
+						valueLookup: item.value?.valueLookup
+							? item.value.valueLookup.map((valueLookup) => ({
+									...valueLookup,
+								}))
+							: undefined,
+						valueNumberMset: item.value?.valueNumberMset
+							? item.value.valueNumberMset.map((valueNumber) => valueNumber)
+							: undefined,
+					},
+				}),
+			),
+		});
+		return this;
+	}
+
+	/**
+	 * Configure if form mocks the control lookup methods
+	 * @param name
+	 * @param updateGridRows
+	 * @returns
+	 */
+	public withLookupControlMethodEventMock(isLookupControlMock: boolean): this {
+		this.isControlLookupMethodMock = isLookupControlMock;
+		return this;
+	}
+
+	/**
+	 * Configure if form mocks contains other form selectors
+	 * @param currentForm
+	 * @param otherItems
+	 * @returns
+	 */
+	public withFormSelectorItems(
+		currentForm: XrmFormMockFormItem,
+		otherItems: XrmFormMockFormItem[],
+	): this {
+		this.formSelectorItems = [
+			...otherItems.map((x) => ({ ...x, isCurrent: false })),
+			{ ...currentForm, isCurrent: true },
+		];
+		return this;
+	}
+
+	/**
+	 * Get mock control in context out of the name string
+	 * @param controlName
+	 * @returns
+	 */
+	public getControl<T extends XrmMockControlType>(
+		controlName: TControlName,
+	): T | null {
+		return <T>this.mockControls.get(controlName) ?? null;
+	}
+
+	/**
+	 * Get mock attribute in context out of the name string
+	 * @param attributeName
+	 * @returns
+	 */
+	public getAttribute<T extends XrmMockAttributeType>(
+		attributeName: TAttributeNames,
+	): T | null {
+		return <T>this.mockAttributes.get(attributeName) ?? null;
+	}
+
+	private InitXrmWebApiServerMocks(): void {
+		this.xrmWebApiMockStubs = {
+			createRecord: jest.fn(
+				(
+					entityLogicalName: string,
+					record: XrmTable.DTO.Table<string>,
+				): Xrm.Async.PromiseLike<Xrm.CreateResponse> => {
+					return Promise.resolve({
+						entityType: entityLogicalName,
+						id: crypto.randomUUID(),
+					}) as unknown as Xrm.Async.PromiseLike<Xrm.CreateResponse>;
+				},
+			),
+			deleteRecord: jest.fn(
+				(entityLogicalName: string, id: string): Xrm.Async.PromiseLike<any> => {
+					return Promise.resolve({
+						entityType: entityLogicalName,
+						id,
+						name: "deleteRecordName",
+					}) as unknown as Xrm.Async.PromiseLike<any>;
+				},
+			),
+			retrieveRecord: jest.fn(
+				(entityLogicalName: string, id: string, options?: string) =>
+					this.RetrieveSingleStubRecord(entityLogicalName, id, options),
+			),
+			retrieveMultipleRecords: jest.fn(
+				(entityLogicalName: string, options?: string, maxPageSize?: number) =>
+					this.RetrieveMultipleRecords(entityLogicalName, options, maxPageSize),
+			),
+			updateRecord: jest.fn(
+				(entityLogicalName: string, id: string, _data: any) =>
+					this.UpdateRecord(entityLogicalName, id),
+			),
+		};
+		jest
+			.spyOn(Xrm.WebApi, "createRecord")
+			.mockImplementation(this.xrmWebApiMockStubs.createRecord);
+		jest
+			.spyOn(Xrm.WebApi, "deleteRecord")
+			.mockImplementation(this.xrmWebApiMockStubs.deleteRecord);
+		jest
+			.spyOn(Xrm.WebApi, "retrieveMultipleRecords")
+			.mockImplementation(this.xrmWebApiMockStubs.retrieveMultipleRecords);
+		jest
+			.spyOn(Xrm.WebApi, "retrieveRecord")
+			.mockImplementation(this.xrmWebApiMockStubs.retrieveRecord);
+		jest
+			.spyOn(Xrm.WebApi, "updateRecord")
+			.mockImplementation(this.xrmWebApiMockStubs.updateRecord);
+	}
+
+	private InitXrmWebApiOnlineMocks(): void {
+		this.xrmWebApiOnlineMockStubs = {
+			execute: jest.fn(
+				(request: XrmWebApi.ExecuteRequest): Xrm.Async.PromiseLike<Response> =>
+					this.GetCustomApiMockResponse(request),
+			),
+			executeMultiple: jest.fn(
+				// only empty response from now
+				(
+					request: XrmWebApi.ExecuteRequest[],
+				): Xrm.Async.PromiseLike<Response[]> =>
+					Promise.resolve([]) as unknown as Xrm.Async.PromiseLike<Response[]>,
+			),
+		};
+		jest
+			.spyOn(Xrm.WebApi.online, "execute")
+			.mockImplementation(this.xrmWebApiOnlineMockStubs.execute);
+	}
+
+	private InitXrmNavigationApiMocks(): void {
+		this.xrmNavigationMockStubs = {
+			navigateTo: jest.fn(
+				(
+					_pageInput:
+						| Xrm.Navigation.PageInputEntityRecord
+						| Xrm.Navigation.PageInputEntityList
+						| Xrm.Navigation.CustomPage
+						| Xrm.Navigation.PageInputHtmlWebResource
+						| Xrm.Navigation.Dashboard,
+					_navigationOptions?: Xrm.Navigation.NavigationOptions,
+				) => {
+					return Promise.resolve() as unknown as Xrm.Async.PromiseLike<void>;
+				},
+			),
+			openAlertDialog: jest.fn(
+				(
+					_alertStrings: Xrm.Navigation.AlertStrings,
+					_alertOptions?: Xrm.Navigation.DialogSizeOptions,
+				) => {
+					return Promise.resolve() as unknown as Xrm.Async.PromiseLike<void>;
+				},
+			),
+			openConfirmDialog: jest.fn(
+				(
+					_confirmString: Xrm.Navigation.ConfirmStrings,
+					confirmOptions?: Xrm.Navigation.DialogSizeOptions,
+				) => {
+					const item = this.confirmDialogConfirmedSeq.find((x) => !x.executed);
+					if (item) {
+						item.executed = true;
+					}
+					/// no dialog seq provided for this dialog... return false by default
+					return Promise.resolve({
+						confirmed: item?.confirmed ?? false,
+					}) as unknown as Xrm.Async.PromiseLike<Xrm.Navigation.ConfirmResult>;
+				},
+			),
+			openErrorDialog: jest.fn(
+				(_errorOptions: Xrm.Navigation.ErrorDialogOptions) => {
+					return Promise.resolve() as unknown as Xrm.Async.PromiseLike<void>;
+				},
+			),
+			openFile: jest.fn(),
+			openForm: jest.fn(),
+			openUrl: jest.fn(),
+			openWebResource: jest.fn(),
+		};
+		jest
+			.spyOn(Xrm.Navigation, "navigateTo")
+			.mockImplementation(this.xrmNavigationMockStubs.navigateTo);
+		jest
+			.spyOn(Xrm.Navigation, "openAlertDialog")
+			.mockImplementation(this.xrmNavigationMockStubs.openAlertDialog);
+		jest
+			.spyOn(Xrm.Navigation, "openConfirmDialog")
+			.mockImplementation(this.xrmNavigationMockStubs.openConfirmDialog);
+		jest
+			.spyOn(Xrm.Navigation, "openErrorDialog")
+			.mockImplementation(this.xrmNavigationMockStubs.openErrorDialog);
+		jest
+			.spyOn(Xrm.Navigation, "openFile")
+			.mockImplementation(this.xrmNavigationMockStubs.openFile);
+		jest
+			.spyOn(Xrm.Navigation, "openForm")
+			.mockImplementation(this.xrmNavigationMockStubs.openForm);
+		jest
+			.spyOn(Xrm.Navigation, "openUrl")
+			.mockImplementation(this.xrmNavigationMockStubs.openUrl);
+		jest
+			.spyOn(Xrm.Navigation, "openWebResource")
+			.mockImplementation(this.xrmNavigationMockStubs.openWebResource);
+	}
+
+	private InitMockFormDataEvent(): void {
+		this.xrmFormDataMockStubs = {
+			getIsDirty: jest.fn(() => this.isFormDataDirty),
+			isValid: jest.fn(() => this.isFormDataValid),
+			refresh: jest.fn((refresh?: boolean): Xrm.Async.PromiseLike<void> => {
+				if (this.refreshErrorMessage) {
+					throw new Error(this.refreshErrorMessage);
+				}
+				return Promise.resolve() as unknown as Xrm.Async.PromiseLike<void>;
+			}),
+			save: jest.fn((): Xrm.Async.PromiseLike<void> => {
+				if (this.saveErrorMessage) {
+					throw new Error(this.saveErrorMessage);
+				}
+				return Promise.resolve() as unknown as Xrm.Async.PromiseLike<void>;
+			}),
+		};
+
+		jest
+			.spyOn(XrmMockGenerator.getFormContext().data, "getIsDirty")
+			.mockImplementation(this.xrmFormDataMockStubs.getIsDirty);
+		jest
+			.spyOn(XrmMockGenerator.getFormContext().data, "isValid")
+			.mockImplementation(this.xrmFormDataMockStubs.isValid);
+		jest
+			.spyOn(XrmMockGenerator.getFormContext().data, "refresh")
+			.mockImplementation(this.xrmFormDataMockStubs.refresh);
+		jest
+			.spyOn(XrmMockGenerator.getFormContext().data, "save")
+			.mockImplementation(this.xrmFormDataMockStubs.save);
+	}
+
+	private InitConsoleMock(): void {
+		this.xrmConsoleMockStubs = {
+			log: jest.fn((_message?: any, ..._optionalParams: any[]) => {}),
+			error: jest.fn((_message?: any, ..._optionalParams: any[]) => {}),
+			debug: jest.fn((_message?: any, ..._optionalParams: any[]) => {}),
+		};
+		jest.spyOn(console, "log").mockImplementation(this.xrmConsoleMockStubs.log);
+		jest
+			.spyOn(console, "error")
+			.mockImplementation(this.xrmConsoleMockStubs.error);
+		jest
+			.spyOn(console, "debug")
+			.mockImplementation(this.xrmConsoleMockStubs.debug);
+	}
+
+	private InitFormUiMocks(): void {
+		this.xrmUiFormMocksStubs = {
+			clearFormNotification: jest.fn((_uniqueId: string): void => {}),
+			close: jest.fn((): void => {}),
+			refreshRibbon: jest.fn((_refreshAll?: boolean): void => {}),
+			setFormNotification: jest.fn(
+				(
+					_message: string,
+					_level: Xrm.FormNotificationLevel,
+					_uniqueId: string,
+				): boolean => {
+					return true;
+				},
+			),
+		};
+
+		jest
+			.spyOn(XrmMockGenerator.getFormContext().ui, "clearFormNotification")
+			.mockImplementation(this.xrmUiFormMocksStubs.clearFormNotification);
+		jest
+			.spyOn(XrmMockGenerator.getFormContext().ui, "close")
+			.mockImplementation(this.xrmUiFormMocksStubs.close);
+		jest
+			.spyOn(XrmMockGenerator.getFormContext().ui, "refreshRibbon")
+			.mockImplementation(this.xrmUiFormMocksStubs.refreshRibbon);
+		jest
+			.spyOn(XrmMockGenerator.getFormContext().ui, "setFormNotification")
+			.mockImplementation(this.xrmUiFormMocksStubs.setFormNotification);
+	}
+
+	private InitXrmUtilityMocks(): void {
+		this.xrmUtilityApiMockStubs = {
+			closeProgressIndicator: jest.fn(),
+			showProgressIndicator: jest.fn(),
+			refreshParentGrid: jest.fn(),
+		};
+		jest
+			.spyOn(Xrm.Utility, "closeProgressIndicator")
+			.mockImplementation(this.xrmUtilityApiMockStubs.closeProgressIndicator);
+		jest
+			.spyOn(Xrm.Utility, "showProgressIndicator")
+			.mockImplementation(this.xrmUtilityApiMockStubs.showProgressIndicator);
+		jest
+			.spyOn(Xrm.Utility, "refreshParentGrid")
+			.mockImplementation(this.xrmUtilityApiMockStubs.refreshParentGrid);
+	}
+
+	private InitFormUiSelector(): void {
+		const currentForm = this.CreateCurrentFormMockItem();
+		const formSelectorMock = XrmMockGenerator.formContext.ui
+			.formSelector as FormSelectorMock;
+		formSelectorMock.items = new ItemCollectionMock<FormItemMock>([
+			currentForm,
+		]);
+		for (const otherItem of this.formSelectorItems.filter(
+			(x) => !x.isCurrent,
+		)) {
+			formSelectorMock.items.push(
+				new FormItemMock({
+					id: otherItem.id,
+					label: otherItem.label ?? "",
+					currentItem: false,
+					formType: otherItem.formType ?? XrmEnum.FormType.Update,
+				}),
+			);
+		}
+		this.AddFormSelectorStubs(formSelectorMock.items.get());
+	}
+
+	private CreateCurrentFormMockItem(): FormItemMock {
+		const currentFormSelector = this.formSelectorItems.find((x) => x.isCurrent);
+		if (currentFormSelector) {
+			// Add with explicitly set data
+			return new FormItemMock({
+				id: currentFormSelector.id,
+				label: currentFormSelector.label ?? "",
+				currentItem: true,
+				formType: currentFormSelector.formType ?? this.formType,
+			});
+		} else {
+			return new FormItemMock({
+				id: "{00000000-0000-0000-0000-000000000000}",
+				label: "current-form",
+				currentItem: true,
+				formType: this.formType,
+			});
+		}
+	}
+
+	private AddFormSelectorStubs(formItemMocks: FormItemMock[]): void {
+		for (const formItemMock of formItemMocks) {
+			const methodMockStub = {
+				navigate: jest.fn(),
+				setVisible: jest.fn((isVisible: boolean): boolean =>
+					this.SetFormSelectorItemVisible(isVisible, formItemMock),
+				),
+				getVisible: jest.fn((): boolean =>
+					this.GetFormSelectorItemVisible(formItemMock),
+				),
+			};
+			this.xrmFormSelectorMockStub[formItemMock.id] = methodMockStub;
+			formItemMock.navigate = methodMockStub.navigate;
+			formItemMock.setVisible = methodMockStub.setVisible;
+			formItemMock.getVisible = methodMockStub.getVisible;
+		}
+	}
+
+	private GetFormSelectorItemVisible(formItemMock: FormItemMock): boolean {
+		const formItem = this.formSelectorItems.find(
+			(x) => x.id === formItemMock.id,
+		);
+		if (!formItem) {
+			throw new Error(`Form item with ${formItemMock.id} not found!`);
+		}
+		// if not explicitly set assume visible
+		return formItem.visible ?? true;
+	}
+
+	private SetFormSelectorItemVisible(
+		isVisible: boolean,
+		formItemMock: FormItemMock,
+	): boolean {
+		const formItem = this.formSelectorItems.find(
+			(x) => x.id === formItemMock.id,
+		);
+		if (!formItem) {
+			throw new Error(`Form item with ${formItemMock.id} not found!`);
+		}
+		formItem.visible = isVisible;
+		return true;
+	}
+
+	private RetrieveMultipleRecords(
+		entityLogicalName: string,
+		options?: string,
+		_maxPageSize?: number,
+	): Xrm.Async.PromiseLike<
+		Xrm.RetrieveMultipleResult<XrmTable.DTO.Table<string>>
+	> {
+		if (this.retrieveServerMockDateError) {
+			return Promise.reject(
+				new Error(this.retrieveServerMockDateError),
+			) as unknown as Xrm.Async.PromiseLike<
+				Xrm.RetrieveMultipleResult<XrmTable.DTO.Table<string>>
+			>;
+		}
+		const entityDTOs = this.serverMockData[entityLogicalName];
+		if (!entityDTOs) {
+			return Promise.resolve({
+				entities: [],
+				nextLink: "",
+			}) as unknown as Xrm.Async.PromiseLike<
+				Xrm.RetrieveMultipleResult<XrmTable.DTO.Table<string>>
+			>;
+		}
+		if (!options) {
+			return Promise.resolve({
+				entities: [...entityDTOs],
+				nextLink: "",
+			}) as unknown as Xrm.Async.PromiseLike<
+				Xrm.RetrieveMultipleResult<XrmTable.DTO.Table<string>>
+			>;
+		}
+		const oDataQueryString = options?.startsWith("?")
+			? options.substring(1)
+			: options;
+		const mockFilterResults =
+			XrmMockFormODataFilter.executeRetrieveMultipleRecord(
+				entityLogicalName,
+				entityDTOs,
+				oDataQueryString,
+			);
+		return Promise.resolve({
+			entities: [...mockFilterResults],
+			nextLink: "",
+		}) as unknown as Xrm.Async.PromiseLike<
+			Xrm.RetrieveMultipleResult<XrmTable.DTO.Table<string>>
+		>;
+	}
+
+	private UpdateRecord(
+		entityLogicalName: string,
+		id: string,
+	): Xrm.Async.PromiseLike<Xrm.UpdateResponse> {
+		if (this.updateServerMockDateError) {
+			return Promise.reject(
+				new Error(this.updateServerMockDateError),
+			) as unknown as Xrm.Async.PromiseLike<Xrm.CreateResponse>;
+		}
+		return Promise.resolve({
+			entityType: entityLogicalName,
+			id,
+		}) as unknown as Xrm.Async.PromiseLike<Xrm.CreateResponse>;
+	}
+
+	private RetrieveSingleStubRecord(
+		entityLogicalName: string,
+		id: string,
+		options?: string,
+	): Xrm.Async.PromiseLike<Partial<XrmTable.DTO.Table<string>>> {
+		const entity = this.serverMockData[entityLogicalName];
+		if (!entity) {
+			throw new Error(`No record not found for entity ${entityLogicalName}`);
+		}
+		const record = entity.find((x) => x[`${entityLogicalName}id`] === id);
+		if (!record) {
+			throw new Error(
+				`Record not found for entity ${entityLogicalName} with ${id}`,
+			);
+		}
+		if (options) {
+			const oDataQueryString = options?.startsWith("?")
+				? options.substring(1)
+				: options;
+			const item = XrmMockFormODataFilter.executeSelectSingleRecord(
+				record,
+				oDataQueryString,
+			);
+			item[`${entityLogicalName}id`] = id;
+			return Promise.resolve({
+				...item,
+			}) as unknown as Xrm.Async.PromiseLike<
+				Partial<XrmTable.DTO.Table<string>>
+			>;
+		}
+		return Promise.resolve(record) as unknown as Xrm.Async.PromiseLike<
+			Partial<XrmTable.DTO.Table<string>>
+		>;
+	}
+
+	private GetCustomApiMockResponse(
+		request: XrmWebApi.ExecuteRequest,
+	): Xrm.Async.PromiseLike<Response> {
+		const apiName = request.getMetadata().operationName;
+		try {
+			if (apiName) {
+				const webApiResponse = this.serverCustomApiMockData[apiName];
+				if (webApiResponse) {
+					return Promise.resolve(
+						new Response(JSON.stringify(webApiResponse)),
+					) as unknown as Xrm.Async.PromiseLike<Response>;
+				}
+				if (this.serverCustomApiExceptions.has(apiName)) {
+					throw new Error(this.serverCustomApiExceptions.get(apiName));
+				}
+			}
+			return Promise.resolve(
+				new Response(
+					JSON.stringify({ error: "no response for received request " }),
+					{
+						status: 400,
+						statusText: XrmMockFormTestContextBuilder.ERROR_NO_CUSTOM_API,
+					},
+				),
+			) as unknown as Xrm.Async.PromiseLike<Response>;
+		} catch (error: any) {
+			throw new Error(error?.message);
+		}
+	}
+
+	private UpdateControlConfig(
+		updateAttributes: XrmFormMockAttributeControlUpdateBase<
+			TControlName,
+			TAttributeNames
+		>[],
+	): void {
+		for (const updateData of updateAttributes) {
+			const control = this.controlConfig.find((x) => {
+				if (updateData.controlSpecificName) {
+					return x.name === updateData.controlSpecificName;
+				}
+				return x.attributeName === updateData.controlAttributeName;
+			});
+			const attribute =
+				this.attributeConfig.find(
+					(x) => x.name === updateData.controlAttributeName,
+				) ?? null;
+			if (updateData.value !== undefined && attribute) {
+				attribute.value = updateData.value;
+			}
+			if (updateData.requiredLevel !== undefined && attribute) {
+				attribute.requiredLevel = updateData.requiredLevel;
+			}
+			if (updateData.isDirty !== undefined && attribute) {
+				attribute.isDirty = updateData.isDirty;
+			}
+			if (updateData.isVisible !== undefined && control) {
+				control.isVisible = updateData.isVisible;
+			}
+			if (updateData.isDisabled !== undefined && control) {
+				control.isDisabled = updateData.isDisabled;
+			}
+		}
+	}
+
+	private UpdateTabConfig(
+		updateTabData: XrmFormTabUpdateData<TTabNames, TSectionNames>,
+	): void {
+		for (const [tabName, tabConfig] of Object.entries<
+			XrmFormTabUpdateBase<TSectionNames>
+		>(updateTabData as Record<string, XrmFormTabUpdateBase<TSectionNames>>)) {
+			const matchTab = this.tabConfig.find((x) => x.name === tabName);
+			if (matchTab) {
+				matchTab.displayState = tabConfig.displayState;
+				matchTab.isVisible = tabConfig.isVisible;
+				this.UpdateTabConfigSections(matchTab, tabConfig);
+			}
+		}
+	}
+
+	private UpdateTabConfigSections(
+		matchTab: XrmForm.Tester.XrmFormMockTab<
+			TTabNames,
+			TSectionNames,
+			TControlName
+		>,
+		tabConfig: XrmFormTabUpdateBase<TSectionNames>,
+	): void {
+		for (const sectionUpdate of tabConfig.sections ?? []) {
+			const matchSection = matchTab.sections.find(
+				(x) => x.name == sectionUpdate.name,
+			);
+			if (matchSection) {
+				matchSection.isVisible = sectionUpdate.isVisible;
+			}
+		}
+	}
+
+	private InitSubGridConfigMockRows(): void {
+		for (const [subGridName, subGridConfig] of this.xrmSubGridConfig) {
+			this.InitSubGridMockRows(subGridName, subGridConfig);
+		}
+	}
+
+	private InitSubGridMockRows(
+		subGridName: TControlName,
+		subGridConfig: XrmFormGridMockRowConfig<string>,
+	): void {
+		const subGridRows: XrmSubGridRowMocks = {
+			selectedGridRowMocksIndexes: [...subGridConfig.selectedRowsIndexes],
+			rows: [],
+		};
+		for (const gridRow of subGridConfig.gridRows) {
+			const gridRowDataMock = this.CreateSubGridRowDataMock(
+				subGridConfig.entityName,
+				gridRow.entityId,
+			);
+			const dataMock = this.CreateSubGridRowEntityDataMock(
+				subGridConfig.subGridRowsAttributeConfig,
+				gridRow,
+				subGridConfig.entityName,
+			);
+			const gridRowMock = new GridRowMock(dataMock, gridRowDataMock);
+			subGridRows.rows.push(gridRowMock);
+		}
+		this.xrmSubGridRowMocks.set(subGridName, subGridRows);
+	}
+
+	private CreateSubGridRowDataMock(
+		entityName: string,
+		entityId: string,
+	): GridRowDataMock {
+		const gridEntityMock = new GridEntityMock({
+			entityType: entityName,
+			id: entityId,
+		});
+		return new GridRowDataMock(gridEntityMock);
+	}
+
+	private CreateSubGridRowEntityDataMock(
+		subGridConfig: XrmForm.Tester.XrmFormMockAttribute<string>[],
+		gridRow: XrmFormGridMockRowConfigRow<string>,
+		entityName: string,
+	): DataMock {
+		const attributeCollection = this.CreateSubGridAttributeDataCollection(
+			subGridConfig,
+			gridRow.subGridRowsAttributes,
+		);
+		const entityMock = new EntityMock({
+			entityName,
+			id: gridRow.entityId,
+			attributes: attributeCollection,
+		});
+		return new DataMock(entityMock);
+	}
+
+	private CreateSubGridAttributeDataCollection(
+		subGridConfig: XrmForm.Tester.XrmFormMockAttribute<string>[],
+		subGridRowsAttributes: XrmFormSubGridAttributeUpdateValue<string>[],
+	): ItemCollectionMock<
+		Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>
+	> {
+		const mergeSubGridRowDefinition = this.MergeSubGridAttributesDefinition(
+			subGridConfig,
+			subGridRowsAttributes,
+		);
+		const mockAttributes: XrmMockAttributeType[] = mergeSubGridRowDefinition
+			.map((x) => this.CreateXrmMockFakeAttribute(x.name, x))
+			.filter((x): x is XrmMockAttributeType => !x);
+		return new ItemCollectionMock<
+			Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>
+		>(
+			<Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>[]>(
+				mockAttributes
+			),
+		);
+	}
+
+	private MergeSubGridAttributesDefinition(
+		subGridConfig: XrmForm.Tester.XrmFormMockAttribute<string>[],
+		subGridRowsAttributes: XrmFormSubGridAttributeUpdateValue<string>[],
+	): XrmForm.Tester.XrmFormMockAttribute<string>[] {
+		return subGridConfig
+			.map((item) => ({
+				...item,
+				options: item.options?.map((opt) => ({ ...opt })),
+				value: {
+					...item.value,
+					valueLookup: item.value?.valueLookup
+						? item.value.valueLookup.map((valueLookup) => ({ ...valueLookup }))
+						: undefined,
+					valueNumberMset: item.value?.valueNumberMset
+						? item.value.valueNumberMset.map((valueNumber) => valueNumber)
+						: undefined,
+				},
+			}))
+			.map((item) => {
+				const rowAttrib = subGridRowsAttributes.find(
+					(x) => x.name === item.name,
+				);
+				if (rowAttrib) {
+					return {
+						...item,
+						value: rowAttrib.value,
+					};
+				}
+				return item;
+			});
+	}
+
+	private InitializeMockFormContextControls(): void {
+		for (const attribute of this.attributeConfig) {
+			const attributeMock = this.CreateXrmFormMockFakeAttribute(
+				attribute.name,
+				attribute,
+			);
+			this.InitAttributeMock(attributeMock, attribute);
+		}
+		for (const control of this.controlConfig) {
+			const controlMock = this.CreateXrmMockFakeControl(control.name, control);
+			this.InitControlMock(controlMock, control);
+		}
+		const formContext = XrmMockGenerator.getFormContext();
+		const attributeCollection = new ItemCollectionMock<
+			Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>
+		>(<Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>[]>[
+			...this.mockAttributes.values(),
+		]);
+		const entityMock = new EntityMock({
+			...this.formEntity,
+			attributes: attributeCollection,
+		});
+		const dataMock = new DataMock(entityMock);
+		formContext.data = dataMock;
+		formContext.data.attributes = attributeCollection;
+		formContext.data.getIsDirty = this.getIsDirty.bind(this);
+		formContext.data.entity.getId = () =>
+			this.formEntity.id ? `{${this.formEntity.id}}` : "";
+	}
+
+	private InitAttributeMock(
+		attributeMock: XrmMockAttributeType | null,
+		attribute: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>,
+	): void {
+		if (attributeMock) {
+			this.mockAttributes.set(attribute.name, attributeMock);
+			if (this.isMockAttributeChanges) {
+				const mockAddOnChange = {
+					addOnChange: jest.fn(),
+					removeOnChange: jest.fn(),
+				};
+				attributeMock.addOnChange = mockAddOnChange.addOnChange;
+				attributeMock.removeOnChange = mockAddOnChange.removeOnChange;
+				this.xrmFormAttributeMethodMockStubs[attribute.name] = mockAddOnChange;
+			}
+		}
+	}
+
+	private InitControlMock(
+		controlMock: XrmMockControlType | null,
+		control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>,
+	): void {
+		if (controlMock) {
+			if (this.isSubGridMethodsMock && this.isGridControl(controlMock)) {
+				const gridControlMock = {
+					refresh: jest.fn(),
+					addOnLoad: jest.fn(),
+					getGrid: jest.fn(
+						(): Xrm.Controls.Grid => this.CreateMockGrid(control),
+					),
+					setFilterXml: jest.fn((_): void => {}),
+				};
+				this.xrmSubGridControlMockStubs[control.name] = gridControlMock;
+				controlMock.addOnLoad = gridControlMock.addOnLoad;
+				controlMock.refresh = gridControlMock.refresh;
+				controlMock.getGrid = gridControlMock.getGrid;
+				(<any>controlMock).setFilterXml = gridControlMock.setFilterXml;
+			}
+			if (this.isControlLookupMethodMock && this.isLookupControl(controlMock)) {
+				const lookupControlMock = {
+					removePreSearch: jest.fn(),
+					addPreSearch: jest.fn(),
+					setEntityTypes: jest.fn((entityType: string[]) => {
+						controlMock.entityTypes = entityType;
+					}),
+					addCustomFilter: jest.fn(),
+				};
+				controlMock.removePreSearch = lookupControlMock.removePreSearch;
+				controlMock.addPreSearch = lookupControlMock.addPreSearch;
+				controlMock.setEntityTypes = lookupControlMock.setEntityTypes;
+				controlMock.addCustomFilter = lookupControlMock.addCustomFilter;
+				this.xrmLookupControlMockStubs[control.name] = lookupControlMock;
+			}
+			if (this.isControlMethodMock && !this.isGridControl(controlMock)) {
+				const standardControl = {
+					addNotification: jest.fn(),
+					clearNotification: jest.fn(),
+					setFocus: jest.fn(),
+					clearOptions: jest.fn(),
+				};
+				controlMock.addNotification = standardControl.addNotification;
+				controlMock.clearNotification = standardControl.clearNotification;
+				controlMock.setFocus = standardControl.setFocus;
+				if (this.isOptionSetControl(controlMock)) {
+					standardControl.clearOptions = jest.fn().mockImplementation(function (
+						this: OptionSetControlMock,
+					) {
+						const optLength = this.options.length;
+						if (optLength) {
+							this.options.splice(0, optLength);
+						}
+						const attOptLength = this.attribute.options.length;
+						if (attOptLength) {
+							this.attribute.options.splice(0, attOptLength);
+						}
+					});
+					controlMock.clearOptions = standardControl.clearOptions;
+					this.xrmOptionSetControlMockStubs[control.name] = standardControl;
+				} else {
+					this.xrmStandardControlMockStubs[control.name] = standardControl;
+				}
+			}
+			this.mockControls.set(control.name, controlMock);
+		}
+	}
+
+	private InitTabs(): this {
+		for (const tabSection of this.tabConfig) {
+			this.InitTab(tabSection);
+		}
+		return this;
+	}
+
+	private InitTab(
+		tab: XrmForm.Tester.XrmFormMockTab<TTabNames, TSectionNames, TControlName>,
+	): this {
+		const mockTab = XrmMockGenerator.Tab.createTab(
+			tab.name,
+			tab.label,
+			tab.isVisible,
+			tab.displayState ?? "collapsed",
+			tab.parent,
+		);
+		if (this.isMockTabEvents) {
+			const tabEvent = {
+				addTabStateChange: jest.fn(),
+				removeTabStateChange: jest.fn(),
+				setFocus: jest.fn(),
+			};
+			mockTab.addTabStateChange = tabEvent.addTabStateChange;
+			mockTab.removeTabStateChange = tabEvent.removeTabStateChange;
+			mockTab.setFocus = tabEvent.setFocus;
+			this.xrmTabEventsStub[tab.name] = tabEvent;
+		}
+		for (const tabSection of tab.sections) {
+			this.InitTabSection(mockTab, tabSection);
+		}
+		return this;
+	}
+
+	private InitPreSaveMock(): void {
+		this.xrmPreSaveEvent = jest.fn();
+		XrmMockGenerator.getFormContext().data.entity.addOnSave =
+			this.xrmPreSaveEvent;
+	}
+
+	private InitTabSection(
+		tab: TabMock,
+		section: XrmForm.Tester.XrmFormMockTabSection<TSectionNames, TControlName>,
+	): this {
+		const controls = this.FilterControlList(section.controlNames);
+		const controlCollection: ItemCollectionMock<Xrm.Controls.Control> =
+			new ItemCollectionMock<Xrm.Controls.Control>(
+				<Xrm.Controls.Control[]>controls,
+			);
+		XrmMockGenerator.Section.createSection(
+			section.name,
+			section.label ?? section.name,
+			section.isVisible ?? false,
+			tab,
+			controlCollection,
+		);
+		return this;
+	}
+
+	private FilterControlList(
+		controlNames: TControlName[],
+	): XrmMockControlType[] {
+		return (
+			controlNames
+				.map((name) => this.mockControls.get(name))
+				.filter((x): x is XrmMockControlType => {
+					return x !== null && x !== undefined;
+				}) ?? []
+		);
+	}
+
+	// Creates mock attributes in the context of the static XrmMockGenerator
+	private CreateXrmFormMockFakeAttribute(
+		name: string,
+		mockAttribute: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>,
+	): XrmMockAttributeType | null {
+		switch (mockAttribute.type) {
+			case "string":
+				return XrmMockGenerator.Attribute.createString({
+					name,
+					value: mockAttribute.value?.valueString,
+					isDirty: mockAttribute?.isDirty,
+					requiredLevel: mockAttribute?.requiredLevel,
+				});
+			case "boolean":
+				return this.CreateFormContextBooleanWithNullReturn(name, mockAttribute);
+			case "date":
+				return XrmMockGenerator.Attribute.createDate({
+					name,
+					value: mockAttribute.value?.valueDate,
+					isDirty: mockAttribute?.isDirty,
+					requiredLevel: mockAttribute?.requiredLevel,
+				});
+			case "number":
+				return XrmMockGenerator.Attribute.createNumber({
+					name,
+					value: mockAttribute.value?.valueNumber,
+					isDirty: mockAttribute?.isDirty,
+					requiredLevel: mockAttribute?.requiredLevel,
+				});
+			case "lookup":
+				return XrmMockGenerator.Attribute.createLookup({
+					name,
+					value: mockAttribute.value?.valueLookup ?? null,
+					isDirty: mockAttribute?.isDirty,
+					requiredLevel: mockAttribute?.requiredLevel,
+				});
+			case "optionSet":
+				return XrmMockGenerator.Attribute.createOptionSet({
+					name,
+					value: mockAttribute.value?.valueNumber,
+					options: mockAttribute.options ?? [],
+					isDirty: mockAttribute?.isDirty,
+					requiredLevel: mockAttribute?.requiredLevel,
+				});
+			case "multiSet":
+				// xrm-mock does not handle multipset controls properly
+				return this.CreateFormContextMultiSelectAttributeMock(
+					name,
+					mockAttribute,
+				);
+			// case "Xrm.Controls.GridControl":
+			// case "Xrm.Controls.KbSearchControl":
+			// case "Xrm.Control.QuickFormControl":
+			// TO BE DONE MOCK GRID CONTROL
+			// return null;
+			default:
+				return null;
+		}
+	}
+
+	// Creates mock attributes not as part of the XrmMockGenerator , e.g. for the subGrid attributes
+	private CreateXrmMockFakeAttribute(
+		name: string,
+		mockAttribute: XrmForm.Tester.XrmFormMockAttribute<string>,
+	): XrmMockAttributeType | null {
+		switch (mockAttribute.type) {
+			case "string":
+				return new StringAttributeMock({
+					name,
+					value: mockAttribute.value?.valueString,
+					isDirty: mockAttribute?.isDirty,
+					requiredLevel: mockAttribute?.requiredLevel,
+				});
+			case "boolean":
+				return new BooleanAttributeMock({
+					name,
+					value: mockAttribute.value?.valueBoolean,
+					isDirty: mockAttribute?.isDirty,
+					requiredLevel: mockAttribute?.requiredLevel,
+				});
+			case "date":
+				return new DateAttributeMock({
+					name,
+					value: mockAttribute.value?.valueDate,
+					isDirty: mockAttribute?.isDirty,
+					requiredLevel: mockAttribute?.requiredLevel,
+				});
+			case "number":
+				return new NumberAttributeMock({
+					name,
+					value: mockAttribute.value?.valueNumber,
+					isDirty: mockAttribute?.isDirty,
+					requiredLevel: mockAttribute?.requiredLevel,
+				});
+			case "lookup":
+				return new LookupAttributeMock({
+					name,
+					value: mockAttribute.value?.valueLookup ?? null,
+					isDirty: mockAttribute?.isDirty,
+					requiredLevel: mockAttribute?.requiredLevel,
+				});
+			case "optionSet":
+				return new OptionSetAttributeMock({
+					name,
+					value: mockAttribute.value?.valueNumber,
+					options: mockAttribute.options ?? [],
+					isDirty: mockAttribute?.isDirty,
+					requiredLevel: mockAttribute?.requiredLevel,
+				});
+			case "multiSet":
+				// xrm-mock does not handle multi set controls properly
+				return this.CreateMultiSelectAttributeMock(name, mockAttribute);
+			// case "Xrm.Controls.GridControl":
+			// case "Xrm.Controls.KbSearchControl":
+			// case "Xrm.Control.QuickFormControl":
+			// TO BE DONE MOCK GRID CONTROL
+			// return null;
+			default:
+				return null;
+		}
+	}
+
+	private CreateFormContextMultiSelectAttributeMock(
+		name: string,
+		mockAttribute: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>,
+	): OptionSetAttributeMock {
+		const multiOptionSetAttr = this.CreateMultiSelectAttributeMock(
+			name,
+			mockAttribute,
+		);
+		return multiOptionSetAttr;
+	}
+
+	private CreateMultiSelectAttributeMock(
+		name: string,
+		mockAttribute: XrmForm.Tester.XrmFormMockAttribute<string>,
+	): OptionSetAttributeMock {
+		const multiOptionSetAttr = new OptionSetAttributeMock({
+			name,
+			value: (mockAttribute.value?.valueNumberMset ?? []) as any,
+			options: mockAttribute.options ?? [],
+			isDirty: mockAttribute?.isDirty,
+			requiredLevel: mockAttribute?.requiredLevel,
+		}) as unknown as Xrm.Attributes.MultiSelectOptionSetAttribute;
+		multiOptionSetAttr.getSelectedOption = (): Xrm.OptionSetValue[] => {
+			const currentValues: number[] = multiOptionSetAttr.getValue() || [];
+			return (mockAttribute.options ?? []).filter((opt) =>
+				currentValues.includes(opt.value),
+			);
+		};
+		return multiOptionSetAttr as unknown as OptionSetAttributeMock;
+	}
+
+	private CreateFormContextBooleanWithNullReturn(
+		name: string,
+		mockAttribute: XrmForm.Tester.XrmFormMockAttribute<TAttributeNames>,
+	): BooleanAttributeMock {
+		const initialValue =
+			mockAttribute.value?.valueBoolean === null
+				? undefined
+				: mockAttribute.value?.valueBoolean;
+		const attributeBoolean = XrmMockGenerator.Attribute.createBoolean({
+			name,
+			initialValue: initialValue,
+			value: initialValue,
+			isDirty: mockAttribute?.isDirty,
+			requiredLevel: mockAttribute?.requiredLevel,
+		});
+		// Known gap of xrm-mock which cannot properly handle the return of empty/null values force the initial assignment to mock the real dynamics behavior
+		attributeBoolean.value = mockAttribute.value?.valueBoolean as any;
+		return attributeBoolean;
+	}
+
+	private CreateXrmMockFakeControl(
+		name: string,
+		control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>,
+	): XrmMockControlType | null {
+		const mockAttribute = control.attributeName
+			? this.mockAttributes.get(control.attributeName)
+			: null;
+		switch (control.type) {
+			case "string":
+				return this.CreateStringMockControl(mockAttribute, control);
+			case "boolean":
+				return this.CreateBooleanMockControl(mockAttribute, control);
+			case "date":
+				return this.CreateDateMockControl(mockAttribute, control);
+			case "number":
+				return this.CreateNumberMockControl(mockAttribute, control);
+			case "lookup":
+				return this.CreateLookupControl(mockAttribute, control);
+			case "optionSet":
+				return this.CreateOptionSetControl(mockAttribute, control);
+			case "multiSet":
+				return this.CreateMultiOptionSetControl(mockAttribute, control);
+			case "gridControl":
+				return XrmMockGenerator.Control.createGrid(name);
+			case "quickView":
+				// create function for quick views
+				return null;
+
+			// case "Xrm.Controls.KbSearchControl":
+			// case "Xrm.Control.QuickFormControl":
+			// case "Xrm.Controls.IframeControl":
+			// case "Xrm.Controls.StandardControl":
+			//     NO MAPPING ON THIS CONTROLS
+			//     return null;
+			default:
+				return null;
+		}
+	}
+
+	private CreateStringMockControl(
+		mockAttribute: XrmMockAttributeType | null | undefined,
+		control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>,
+	): StringControlMock | null {
+		if (mockAttribute && control.name) {
+			return XrmMockGenerator.Control.createString({
+				name: control.name,
+				attribute: <StringAttributeMock>mockAttribute,
+				visible: control.isVisible,
+				disabled: control.isDisabled,
+			});
+		}
+		return null;
+	}
+
+	private CreateBooleanMockControl(
+		mockAttribute: XrmMockAttributeType | null | undefined,
+		control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>,
+	): BooleanControlMock | null {
+		if (mockAttribute && control.name) {
+			return XrmMockGenerator.Control.createBoolean({
+				name: control.name,
+				attribute: <BooleanAttributeMock>mockAttribute,
+				visible: control.isVisible,
+				disabled: control.isDisabled,
+			});
+		}
+		return null;
+	}
+
+	private CreateDateMockControl(
+		mockAttribute: XrmMockAttributeType | null | undefined,
+		control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>,
+	): DateControlMock | null {
+		if (mockAttribute && control.name) {
+			return XrmMockGenerator.Control.createDate({
+				name: control.name,
+				attribute: <DateAttributeMock>mockAttribute,
+				visible: control.isVisible,
+				disabled: control.isDisabled,
+			});
+		}
+		return null;
+	}
+
+	private CreateNumberMockControl(
+		mockAttribute: XrmMockAttributeType | null | undefined,
+		control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>,
+	): NumberControlMock | null {
+		if (mockAttribute && control.name) {
+			return XrmMockGenerator.Control.createNumber({
+				name: control.name,
+				attribute: <NumberAttributeMock>mockAttribute,
+				visible: control.isVisible,
+				disabled: control.isDisabled,
+			});
+		}
+		return null;
+	}
+
+	private CreateLookupControl(
+		mockAttribute: XrmMockAttributeType | null | undefined,
+		control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>,
+	): LookupControlMock | null {
+		if (mockAttribute && control.name) {
+			return XrmMockGenerator.Control.createLookup({
+				name: control.name,
+				attribute: <LookupAttributeMock>mockAttribute,
+				visible: control.isVisible,
+				disabled: control.isDisabled,
+			});
+		}
+		return null;
+	}
+
+	private CreateOptionSetControl(
+		mockAttribute: XrmMockAttributeType | null | undefined,
+		control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>,
+	): OptionSetControlMock | null {
+		if (mockAttribute && control.name) {
+			const mockOptions = (<OptionSetAttributeMock>mockAttribute).options ?? [];
+			return XrmMockGenerator.Control.createOptionSet({
+				name: control.name,
+				attribute: <OptionSetAttributeMock>mockAttribute,
+				visible: control.isVisible,
+				options: mockOptions.map((opt) => ({ ...opt })),
+				disabled: control.isDisabled,
+			});
+		}
+		return null;
+	}
+
+	private CreateMultiOptionSetControl(
+		mockAttribute: XrmMockAttributeType | null | undefined,
+		control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>,
+	): OptionSetControlMock | null {
+		if (mockAttribute && control.name) {
+			const mockOptions = (<OptionSetAttributeMock>mockAttribute).options ?? [];
+			return XrmMockGenerator.Control.createOptionSet({
+				name: control.name,
+				attribute: mockAttribute as any,
+				visible: control.isVisible,
+				options: mockOptions.map((opt) => ({ ...opt })),
+				disabled: control.isDisabled,
+			});
+		}
+		return null;
+	}
+
+	private CreateMockGrid(
+		control: XrmForm.Tester.XrmFormMockControl<TControlName, TAttributeNames>,
+	): GridMock {
+		const gridRows = this.xrmSubGridRowMocks.get(control.name);
+		if (!gridRows) {
+			return new GridMock(
+				new ItemCollectionMock([]),
+				new ItemCollectionMock([]),
+			);
+		}
+		const selectedRows = gridRows.rows.filter((_, index) => {
+			if (gridRows.selectedGridRowMocksIndexes.length > 0) {
+				return gridRows.selectedGridRowMocksIndexes.includes(index);
+			}
+			return false;
+		});
+		return new GridMock(
+			new ItemCollectionMock(gridRows.rows),
+			new ItemCollectionMock(selectedRows),
+		);
+	}
+
+	private MapFormContext(): ContextMock {
+		const context = Context.createContext();
+		context.clientUrl = this.clientUrl ?? "";
+		context.userSettings.languageId = this.languageId;
+		context.userSettings.roles = new ItemCollectionMock(this.userRoles);
+		return context;
+	}
+
+	private getIsDirty() {
+		return Array.from(this.mockAttributes).some(([name, attr]) => attr.isDirty);
+	}
+
+	private isGridControl(
+		control: XrmMockControlType | null,
+	): control is GridControlMock {
+		if (!control) {
+			return false;
+		}
+		const controlType = control.getControlType();
+		return controlType === "subgrid";
+	}
+
+	private isLookupControl(
+		control: XrmMockControlType | null,
+	): control is LookupControlMock {
+		if (!control) {
+			return false;
+		}
+		const controlType = control.getControlType();
+		return controlType === "lookup";
+	}
+
+	private isOptionSetControl(
+		control: XrmMockControlType | null,
+	): control is OptionSetControlMock {
+		if (!control) {
+			return false;
+		}
+		const controlType = control.getControlType();
+		return controlType === "optionset";
+	}
 }

--- a/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_test_context_types.ts
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_test_context_types.ts
@@ -1,185 +1,280 @@
 import {
-    BooleanAttributeMock,
-    BooleanControlMock,
-    DateAttributeMock,
-    DateControlMock,
-    GridControlMock,
-    GridRowMock,
-    LookupAttributeMock,
-    LookupControlMock,
-    NumberAttributeMock,
-    NumberControlMock,
-    OptionSetAttributeMock,
-    OptionSetControlMock,
-    StringAttributeMock,
-    StringControlMock,
+	BooleanAttributeMock,
+	BooleanControlMock,
+	DateAttributeMock,
+	DateControlMock,
+	GridControlMock,
+	GridRowMock,
+	LookupAttributeMock,
+	LookupControlMock,
+	NumberAttributeMock,
+	NumberControlMock,
+	OptionSetAttributeMock,
+	OptionSetControlMock,
+	StringAttributeMock,
+	StringControlMock,
 } from "xrm-mock";
 import { EventContextWithEventArgsMock } from "xrm-mock/dist/xrm-mock/events/eventcontextwitheventargs.mock";
 
 export type XrmMockAttributeType =
-    | StringAttributeMock
-    | BooleanAttributeMock
-    | DateAttributeMock
-    | NumberAttributeMock
-    | LookupAttributeMock
-    | OptionSetAttributeMock;
+	| StringAttributeMock
+	| BooleanAttributeMock
+	| DateAttributeMock
+	| NumberAttributeMock
+	| LookupAttributeMock
+	| OptionSetAttributeMock;
 
 export type XrmMockControlType =
-    | BooleanControlMock
-    | DateControlMock
-    | GridControlMock
-    | LookupControlMock
-    | NumberControlMock
-    | OptionSetControlMock
-    | StringControlMock;
+	| BooleanControlMock
+	| DateControlMock
+	| GridControlMock
+	| LookupControlMock
+	| NumberControlMock
+	| OptionSetControlMock
+	| StringControlMock;
 
 export interface XrmMockConfirmDialogResponses {
-    confirmed: boolean;
-    executed: boolean;
+	confirmed: boolean;
+	executed: boolean;
 }
 
 export interface XrmFormMockFormItem {
-    id: string;
-    label?: string;
-    visible?: boolean;
-    formType?: XrmEnum.FormType;
-    isCurrent?: boolean;
+	id: string;
+	label?: string;
+	visible?: boolean;
+	formType?: XrmEnum.FormType;
+	isCurrent?: boolean;
 }
 
-export interface XrmFormMockAttributeControlUpdateBase<CtlNames extends string, AttNames extends string> {
-    isDisabled?: boolean;
-    isVisible?: boolean;
-    isDirty?: boolean;
-    controlAttributeName: AttNames;
-    controlSpecificName?: CtlNames;
-    requiredLevel?: Xrm.Attributes.RequirementLevel;
-    value?: XrmForm.Tester.XrmMockAttributeValue;
+export interface XrmFormMockAttributeControlUpdateBase<
+	CtlNames extends string,
+	AttNames extends string,
+> {
+	isDisabled?: boolean;
+	isVisible?: boolean;
+	isDirty?: boolean;
+	controlAttributeName: AttNames;
+	controlSpecificName?: CtlNames;
+	requiredLevel?: Xrm.Attributes.RequirementLevel;
+	value?: XrmForm.Tester.XrmMockAttributeValue;
 }
 
 export interface XrmFormSectionUpdateBase<TabSectionName extends string> {
-    name: TabSectionName;
-    isVisible?: boolean;
+	name: TabSectionName;
+	isVisible?: boolean;
 }
 
 export interface XrmFormTabUpdateBase<TabSectionName extends string> {
-    isVisible?: boolean;
-    displayState?: Xrm.DisplayState;
-    sections?: XrmFormSectionUpdateBase<TabSectionName>[];
+	isVisible?: boolean;
+	displayState?: Xrm.DisplayState;
+	sections?: XrmFormSectionUpdateBase<TabSectionName>[];
 }
 
 export interface XrmFormSubGridAttributeUpdateValue<AttNames extends string> {
-    name: AttNames;
-    value?: XrmForm.Tester.XrmMockAttributeValue;
+	name: AttNames;
+	value?: XrmForm.Tester.XrmMockAttributeValue;
 }
 
 export interface XrmFormGridMockRowConfig<TGridAttributeNames extends string> {
-    entityName: string;
-    subGridRowsAttributeConfig: XrmForm.Tester.XrmFormMockAttribute<TGridAttributeNames>[];
-    gridRows: XrmFormGridMockRowConfigRow<TGridAttributeNames>[];
-    selectedRowsIndexes: number[];
+	entityName: string;
+	subGridRowsAttributeConfig: XrmForm.Tester.XrmFormMockAttribute<TGridAttributeNames>[];
+	gridRows: XrmFormGridMockRowConfigRow<TGridAttributeNames>[];
+	selectedRowsIndexes: number[];
 }
 
-export interface XrmFormGridMockRowConfigRow<TGridAttributeNames extends string> {
-    entityId: string;
-    subGridRowsAttributes: XrmFormSubGridAttributeUpdateValue<TGridAttributeNames>[];
+export interface XrmFormGridMockRowConfigRow<
+	TGridAttributeNames extends string,
+> {
+	entityId: string;
+	subGridRowsAttributes: XrmFormSubGridAttributeUpdateValue<TGridAttributeNames>[];
 }
 
 export interface XrmSubGridRowMocks {
-    rows: GridRowMock[];
-    selectedGridRowMocksIndexes: number[];
+	rows: GridRowMock[];
+	selectedGridRowMocksIndexes: number[];
 }
 
-export type XrmFormMockServerData = Record<string, XrmTable.DTO.Table<string>[]>;
+export type XrmFormMockServerData = Record<string, unknown[]>;
 export type XrmCustomApiMockData = Record<string, XrmWebApi.ExecuteResponse>;
 
-export type XrmWebApiMockStubMethods = jest.FunctionPropertyNames<Required<Xrm.WebApi>>;
-export type XrmWebApiOnlineMockStubMethod = jest.FunctionPropertyNames<Required<Xrm.WebApiOnline>>;
-export type XrmNavigationApiMockStubMethods = jest.FunctionPropertyNames<Required<Xrm.Navigation>>;
-export type XrmUtilityApiMockStubMethod = jest.FunctionPropertyNames<Required<Xrm.Utility>>;
-export type XrmFormContextDataStubMethod = jest.FunctionPropertyNames<Required<Xrm.Data>>;
-export type XrmFormContextUiNotificationMethods = jest.FunctionPropertyNames<Required<Xrm.Ui>>;
-export type XrmSubGridMethodName = jest.FunctionPropertyNames<Required<Xrm.Controls.GridControl>>;
-export type XrmLookupControlMethodName = jest.FunctionPropertyNames<Required<Xrm.Controls.LookupControl>>;
-export type XrmFormTabMethodNames = jest.FunctionPropertyNames<Required<Xrm.Controls.Tab>>;
-export type XrmFormControlMethodNames = jest.FunctionPropertyNames<Required<Xrm.Controls.StandardControl>>;
-export type XrmOptionSetControlMethodNames = jest.FunctionPropertyNames<Required<Xrm.Controls.OptionSetControl>>;
-export type XrmFormAttributeMethods = jest.FunctionPropertyNames<Required<Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>>>;
-export type XrmConsoleStubMethod = jest.FunctionPropertyNames<Required<typeof console>>;
-export type XrmFormSelectorItemStubMethod = jest.FunctionPropertyNames<Required<Xrm.Controls.FormItem>>;
-
-export type XrmWebApiMockStubs = Partial<Record<XrmWebApiMockStubMethods, jest.Mock>>;
-export type XrmWebApiOnlineMockStubs = Partial<Record<XrmWebApiOnlineMockStubMethod, jest.Mock>>;
-export type XrmNavigationMockStubs = Partial<Record<XrmNavigationApiMockStubMethods, jest.Mock>>;
-export type XrmUtilityApiMockStubs = Partial<Record<XrmUtilityApiMockStubMethod, jest.Mock>>;
-export type XrmFormContextUiMockStubs = Partial<Record<XrmFormContextUiNotificationMethods, jest.Mock>>;
-export type XrmFormContextDataMockStubs = Partial<Record<XrmFormContextDataStubMethod, jest.Mock>>;
-export type XrmFormSelectorItemMockStubs = Partial<Record<XrmFormSelectorItemStubMethod, jest.Mock>>;
-export type XrmConsoleMockStubs = Partial<Record<XrmConsoleStubMethod, jest.Mock>>;
-export type XrmSubGridMockStubs = Partial<Record<XrmSubGridMethodName | "setFilterXml", jest.Mock>>;
-export type XrmStandardMockStubs = Partial<Record<XrmFormControlMethodNames, jest.Mock>>;
-export type XrmOptionSetMockStubs = Partial<Record<XrmOptionSetControlMethodNames, jest.Mock>>;
-export type XrmLookupMockStubs = Partial<Record<XrmLookupControlMethodName, jest.Mock>>;
-
-export type XrmTabEventMockStubs = Partial<Record<XrmFormTabMethodNames, jest.Mock>>;
-export type XrmFormAttributeMockStubs = Partial<Record<XrmFormAttributeMethods, jest.Mock>>;
-
-export type XrmFormAttributeMethodMockStubs<TAttributeNames extends string> = Partial<Record<TAttributeNames, XrmFormAttributeMockStubs>>;
-export type XrmSubGridControlMockStubs<TControlName extends string> = Partial<Record<TControlName, XrmSubGridMockStubs>>;
-export type XrmFormSelectorMockStubs = Partial<Record<string, XrmFormSelectorItemMockStubs>>;
-export type XrmLookupControlMockStubs<TControlName extends string> = Partial<Record<TControlName, XrmLookupMockStubs>>;
-export type XrmStandardControlMockStubs<TControlName extends string> = Partial<Record<TControlName, XrmStandardMockStubs>>;
-export type XrmOptionSetControlMockStubs<TControlName extends string> = Partial<Record<TControlName, XrmOptionSetMockStubs>>;
-export type XrmFormContextTabEventsStub<TTabNames extends string> = Partial<Record<TTabNames, XrmTabEventMockStubs>>;
-export type XrmFormTabUpdateData<TTabNames extends string, TTabSectionNames extends string> = Partial<
-    Record<TTabNames, XrmFormTabUpdateBase<TTabSectionNames>>
+export type XrmWebApiMockStubMethods = jest.FunctionPropertyNames<
+	Required<Xrm.WebApi>
+>;
+export type XrmWebApiOnlineMockStubMethod = jest.FunctionPropertyNames<
+	Required<Xrm.WebApiOnline>
+>;
+export type XrmNavigationApiMockStubMethods = jest.FunctionPropertyNames<
+	Required<Xrm.Navigation>
+>;
+export type XrmUtilityApiMockStubMethod = jest.FunctionPropertyNames<
+	Required<Xrm.Utility>
+>;
+export type XrmFormContextDataStubMethod = jest.FunctionPropertyNames<
+	Required<Xrm.Data>
+>;
+export type XrmFormContextUiNotificationMethods = jest.FunctionPropertyNames<
+	Required<Xrm.Ui>
+>;
+export type XrmSubGridMethodName = jest.FunctionPropertyNames<
+	Required<Xrm.Controls.GridControl>
+>;
+export type XrmLookupControlMethodName = jest.FunctionPropertyNames<
+	Required<Xrm.Controls.LookupControl>
+>;
+export type XrmFormTabMethodNames = jest.FunctionPropertyNames<
+	Required<Xrm.Controls.Tab>
+>;
+export type XrmFormControlMethodNames = jest.FunctionPropertyNames<
+	Required<Xrm.Controls.StandardControl>
+>;
+export type XrmOptionSetControlMethodNames = jest.FunctionPropertyNames<
+	Required<Xrm.Controls.OptionSetControl>
+>;
+export type XrmFormAttributeMethods = jest.FunctionPropertyNames<
+	Required<Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>>
+>;
+export type XrmConsoleStubMethod = jest.FunctionPropertyNames<
+	Required<typeof console>
+>;
+export type XrmFormSelectorItemStubMethod = jest.FunctionPropertyNames<
+	Required<Xrm.Controls.FormItem>
 >;
 
+export type XrmWebApiMockStubs = Partial<
+	Record<XrmWebApiMockStubMethods, jest.Mock>
+>;
+export type XrmWebApiOnlineMockStubs = Partial<
+	Record<XrmWebApiOnlineMockStubMethod, jest.Mock>
+>;
+export type XrmNavigationMockStubs = Partial<
+	Record<XrmNavigationApiMockStubMethods, jest.Mock>
+>;
+export type XrmUtilityApiMockStubs = Partial<
+	Record<XrmUtilityApiMockStubMethod, jest.Mock>
+>;
+export type XrmFormContextUiMockStubs = Partial<
+	Record<XrmFormContextUiNotificationMethods, jest.Mock>
+>;
+export type XrmFormContextDataMockStubs = Partial<
+	Record<XrmFormContextDataStubMethod, jest.Mock>
+>;
+export type XrmFormSelectorItemMockStubs = Partial<
+	Record<XrmFormSelectorItemStubMethod, jest.Mock>
+>;
+export type XrmConsoleMockStubs = Partial<
+	Record<XrmConsoleStubMethod, jest.Mock>
+>;
+export type XrmSubGridMockStubs = Partial<
+	Record<XrmSubGridMethodName | "setFilterXml", jest.Mock>
+>;
+export type XrmStandardMockStubs = Partial<
+	Record<XrmFormControlMethodNames, jest.Mock>
+>;
+export type XrmOptionSetMockStubs = Partial<
+	Record<XrmOptionSetControlMethodNames, jest.Mock>
+>;
+export type XrmLookupMockStubs = Partial<
+	Record<XrmLookupControlMethodName, jest.Mock>
+>;
+
+export type XrmTabEventMockStubs = Partial<
+	Record<XrmFormTabMethodNames, jest.Mock>
+>;
+export type XrmFormAttributeMockStubs = Partial<
+	Record<XrmFormAttributeMethods, jest.Mock>
+>;
+
+export type XrmFormAttributeMethodMockStubs<TAttributeNames extends string> =
+	Partial<Record<TAttributeNames, XrmFormAttributeMockStubs>>;
+export type XrmSubGridControlMockStubs<TControlName extends string> = Partial<
+	Record<TControlName, XrmSubGridMockStubs>
+>;
+export type XrmFormSelectorMockStubs = Partial<
+	Record<string, XrmFormSelectorItemMockStubs>
+>;
+export type XrmLookupControlMockStubs<TControlName extends string> = Partial<
+	Record<TControlName, XrmLookupMockStubs>
+>;
+export type XrmStandardControlMockStubs<TControlName extends string> = Partial<
+	Record<TControlName, XrmStandardMockStubs>
+>;
+export type XrmOptionSetControlMockStubs<TControlName extends string> = Partial<
+	Record<TControlName, XrmOptionSetMockStubs>
+>;
+export type XrmFormContextTabEventsStub<TTabNames extends string> = Partial<
+	Record<TTabNames, XrmTabEventMockStubs>
+>;
+export type XrmFormTabUpdateData<
+	TTabNames extends string,
+	TTabSectionNames extends string,
+> = Partial<Record<TTabNames, XrmFormTabUpdateBase<TTabSectionNames>>>;
+
 export interface IXrmMockFormTestContextBuilder<
-    TTabNames extends string,
-    TSectionNames extends string,
-    TControlName extends string,
-    TAttributeNames extends string,
+	TTabNames extends string,
+	TSectionNames extends string,
+	TControlName extends string,
+	TAttributeNames extends string,
 > {
-    buildMockFormContext(): this;
-    getAttribute<T extends XrmMockAttributeType>(attributeName: TAttributeNames): T | null;
-    getControl<T extends XrmMockControlType>(controlName: TControlName): T | null;
-    getExecutionContextWithSource(
-        source: Xrm.Attributes.Attribute | Xrm.Controls.Control | Xrm.Entity
-    ): EventContextWithEventArgsMock<Xrm.Events.EventContext>;
-    getMockFormContext<T extends Xrm.FormContext>(): T;
-    getLoadExecutionContext(): EventContextWithEventArgsMock<Xrm.Events.LoadEventArguments>;
-    withAttributeMockChange(isMockAttributeChanges: boolean): this;
-    withClientUrl(clientUrl: string): this;
-    withConsoleMocked(isConsoleMocked: boolean): this;
-    WithControlMethodMock(isControlMethodMock: boolean): this;
-    withCustomApi<T extends XrmWebApi.ExecuteResponse>(name: string, response: T): this;
-    withCustomApiException(name: string, errorMsg: string): this;
-    withCustomApis(data: XrmCustomApiMockData): this;
-    withEntity(entityName: string, entityId: string): this;
-    withFetchResponse(statusCode: number, response: string): this;
-    withFetchException(errorMsg: string): this;
-    withFormAttributeControlData(updateData: XrmFormMockAttributeControlUpdateBase<TControlName, TAttributeNames>[]): this;
-    withFormDataDirty(isDirty: boolean): this;
-    withFormDataEventMock(isMockFormDateEventMock: boolean): this;
-    withFormDataValid(isValid: boolean): this;
-    withFormSelectorItems(currentForm: XrmFormMockFormItem, otherItems: XrmFormMockFormItem[]): this;
-    withFormTabData(updateData: XrmFormTabUpdateData<TTabNames, TSectionNames>): this;
-    withFormType(type: XrmEnum.FormType): this;
-    withFormUiEventMock(isMockFormUiEvent: boolean): this;
-    withLanguageId(languageId: number): this;
-    withLookupControlMethodEventMock(isLookupControlMock: boolean): this;
-    withPreSaveEventMock(isPreSaveEventMock: boolean): this;
-    withRefreshErrorMessage(errorMsg: string | null): this;
-    withRegisterTabEventsMocks(isMockTabEvents: boolean): this;
-    withRetrieveServerDataError(erroMsg: string): this;
-    withSaveErrorMessage(errorMsg: string | null): this;
-    withServerData(data: XrmFormMockServerData): this;
-    withSubGridMethodsMock(isSubGridLoad: boolean): this;
-    withSubGridMockRows<TGridAttributeNames extends string>(
-        name: TControlName,
-        updateGridRows: XrmFormGridMockRowConfig<TGridAttributeNames>
-    ): this;
-    withUpdateServerDateErrorMessage(erroMsg: string): this;
-    withUserConfirmDialogSeq(confirmDialogConfirmed: boolean[]): this;
-    withUserRoles(roles: Xrm.LookupValue[]): this;
+	buildMockFormContext(): this;
+	getAttribute<T extends XrmMockAttributeType>(
+		attributeName: TAttributeNames,
+	): T | null;
+	getControl<T extends XrmMockControlType>(controlName: TControlName): T | null;
+	getExecutionContextWithSource(
+		source: Xrm.Attributes.Attribute | Xrm.Controls.Control | Xrm.Entity,
+	): EventContextWithEventArgsMock<Xrm.Events.EventContext>;
+	getMockFormContext<T extends Xrm.FormContext>(): T;
+	getLoadExecutionContext(): EventContextWithEventArgsMock<Xrm.Events.LoadEventArguments>;
+	withAttributeMockChange(isMockAttributeChanges: boolean): this;
+	withClientUrl(clientUrl: string): this;
+	withConsoleMocked(isConsoleMocked: boolean): this;
+	WithControlMethodMock(isControlMethodMock: boolean): this;
+	withCustomApi<T extends XrmWebApi.ExecuteResponse>(
+		name: string,
+		response: T,
+	): this;
+	withCustomApiException(name: string, errorMsg: string): this;
+	withCustomApis(data: XrmCustomApiMockData): this;
+	withEntity(entityName: string, entityId: string): this;
+	withFetchResponse(statusCode: number, response: string): this;
+	withFetchException(errorMsg: string): this;
+	withFormAttributeControlData(
+		updateData: XrmFormMockAttributeControlUpdateBase<
+			TControlName,
+			TAttributeNames
+		>[],
+	): this;
+	withFormDataDirty(isDirty: boolean): this;
+	withFormDataEventMock(isMockFormDateEventMock: boolean): this;
+	withFormDataValid(isValid: boolean): this;
+	withFormSelectorItems(
+		currentForm: XrmFormMockFormItem,
+		otherItems: XrmFormMockFormItem[],
+	): this;
+	withFormTabData(
+		updateData: XrmFormTabUpdateData<TTabNames, TSectionNames>,
+	): this;
+	withFormType(type: XrmEnum.FormType): this;
+	withFormUiEventMock(isMockFormUiEvent: boolean): this;
+	withLanguageId(languageId: number): this;
+	withLookupControlMethodEventMock(isLookupControlMock: boolean): this;
+	withPreSaveEventMock(isPreSaveEventMock: boolean): this;
+	withRefreshErrorMessage(errorMsg: string | null): this;
+	withRegisterTabEventsMocks(isMockTabEvents: boolean): this;
+	withRetrieveServerDataError(erroMsg: string): this;
+	withSaveErrorMessage(errorMsg: string | null): this;
+	withServerData(data: XrmFormMockServerData): this;
+	withSelectedSubGridRows(
+		name: TControlName,
+		entityName: string,
+		selectedIds: string[],
+	): this;
+	withSubGridMethodsMock(isSubGridLoad: boolean): this;
+	withSubGridMockRows<TGridAttributeNames extends string>(
+		name: TControlName,
+		updateGridRows: XrmFormGridMockRowConfig<TGridAttributeNames>,
+	): this;
+	withUpdateServerDateErrorMessage(erroMsg: string): this;
+	withUserConfirmDialogSeq(confirmDialogConfirmed: boolean[]): this;
+	withUserRoles(roles: Xrm.LookupValue[]): this;
 }

--- a/tests/dgt.power.codegeneration.tests/TslTemplateContractTests.cs
+++ b/tests/dgt.power.codegeneration.tests/TslTemplateContractTests.cs
@@ -24,6 +24,14 @@ public class TslTemplateContractTests
             new RenderCase("Entity.liquid", CreateEntityModel(), "account", null, "account.entity.d.ts", "namespace XrmTable.Account"),
             new RenderCase("EntityForm.liquid", CreateFormModel(), "account", "account.main.default", "account.main.form.d.ts", "declare namespace XrmForm.Account"),
             new RenderCase("EntityFormTestHelper.liquid", CreateFormModel(), "account", "account.main.default", "account.main.testhelper.ts", "TestHelper"),
+            new RenderCase("EntityFormTestHelper.liquid", CreateFormModel(), "account", "account.main.default", "account.main.testhelper.ts", "export function createBuilder"),
+            new RenderCase("EntityFormTestHelper.liquid", CreateFormModel(), "account", "account.main.default", "account.main.testhelper.ts", "export interface CreateBuilderOptions"),
+            new RenderCase("EntityFormTestHelper.liquid", CreateFormModel(), "account", "account.main.default", "account.main.testhelper.ts", "languageId?: number"),
+            new RenderCase("EntityFormTestHelper.liquid", CreateFormModel(), "account", "account.main.default", "account.main.testhelper.ts", "export type FormContext"),
+            new RenderCase("EntityFormTestHelper.liquid", CreateFormModel(), "account", "account.main.default", "account.main.testhelper.ts", "export type ControlName"),
+            new RenderCase("EntityFormTestHelper.liquid", CreateFormModel(), "account", "account.main.default", "account.main.testhelper.ts", "export type AttributeName"),
+            new RenderCase("EntityFormTestHelper.liquid", CreateFormModelWithTabs(), "account", "account.main.default", "account.main.testhelper.ts", "export type TabName"),
+            new RenderCase("EntityFormTestHelper.liquid", CreateFormModelWithTabsAndSections(), "account", "account.main.default", "account.main.testhelper.ts", "export type SectionNames"),
             new RenderCase("OptionSets.liquid", CreateOptionSetModel(), null, null, "optionsetvalues.d.ts", "declare namespace XrmEnum"),
             new RenderCase("SdkMessages.liquid", CreateSdkMessagesModel(), null, null, "sdkmessagenames.d.ts", "declare namespace XrmMetadata"),
             new RenderCase("CustomApi.liquid", CreateCustomApiModel(), "sample_customapi", null, "sample_customapi.customapi.d.ts", "declare namespace XrmCustomApi")
@@ -137,6 +145,28 @@ public class TslTemplateContractTests
             Attributes = [attribute],
             BpfControls = []
         };
+    }
+
+    private static FormViewModel CreateFormModelWithTabs()
+    {
+        var viewModel = CreateFormModel();
+        viewModel.FormDetail.TabDetails.Add(new TabDetail
+        {
+            TabName = "general"
+        });
+        return viewModel;
+    }
+
+    private static FormViewModel CreateFormModelWithTabsAndSections()
+    {
+        var viewModel = CreateFormModel();
+        var tab = new TabDetail
+        {
+            TabName = "general"
+        };
+        tab.Sections.Add(new KeyValuePair<string, SectionDetail>("details", new SectionDetail()));
+        viewModel.FormDetail.TabDetails.Add(tab);
+        return viewModel;
     }
 
     private static OptionSetViewModel CreateOptionSetModel() =>


### PR DESCRIPTION
Implements #175.

## Changes

- **Generated `*.mock.form.ts` helpers**
  - Add `createBuilder(options?)` factory function with optional `languageId`.
  - Re-export convenience type aliases: `FormContext`, `ControlName`, `AttributeName`, `TabName` (when tabs exist) and `SectionNames` (when sections exist).

- **Runtime helper improvements**
  - Relax `XrmFormMockServerData` to `Record<string, unknown[]>` for more flexible mock data.
  - Add `withSelectedSubGridRows(...)` on the builder, which automatically enables sub-grid method mocking.
  - Fix `retrieveMultipleRecords` to return full records when no `$select` is provided instead of returning only `id`.

- **Tests**
  - Extend `TslTemplateContractTests` with assertions for all new generated fragments and conditional type aliases.

## Verification

- `dotnet test --project tests/dgt.power.codegeneration.tests` → 57 passed, 0 failed.

## Follow-up

The remaining TypeScript legacy issues (`any`-casts, loose equality in `xrm_mock_form_odata_filter.ts`) are intentionally left untouched and tracked in #176.

Closes #175