### PR TITLE
fix(codegeneration): keep subgrid row attributes instead of discarding them

### DIFF
--- a/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_test_context_builder.ts
+++ b/src/modules/dgt.power.codegeneration/Templates/tsl/xrm_mock_form_test_context_builder.ts
@@ -1336,7 +1336,7 @@ export class XrmMockFormTestContextBuilder<
 		);
 		const mockAttributes: XrmMockAttributeType[] = mergeSubGridRowDefinition
 			.map((x) => this.CreateXrmMockFakeAttribute(x.name, x))
-			.filter((x): x is XrmMockAttributeType => !x);
+			.filter((x): x is XrmMockAttributeType => !!x);
 		return new ItemCollectionMock<
 			Xrm.Attributes.Attribute<Xrm.Attributes.AttributeValues>
 		>(


### PR DESCRIPTION
Fixes the inverted boolean predicate in `CreateSubGridAttributeDataCollection`.

Previously the filter `!x` kept `null` values and removed all valid mock attributes, so selected sub-grid rows exposed an empty attribute collection. Ribbon / form tests reading row attributes (e.g. hidden lookup fields like `crmikpk_participantid`) therefore failed.

Closes #179